### PR TITLE
接用rt_thread bsp工程 使用env打开AT组件加入ec20代码，然后进行更新后，发现编译错误。

### DIFF
--- a/at_socket_ec20.c
+++ b/at_socket_ec20.c
@@ -782,7 +782,8 @@ static int ec20_domain_resolve(const char *name, char ip[16])
             /* waiting result event from AT URC, the device default connection timeout is 60 seconds.*/
             if (at_socket_event_recv(EC20_EVENT_DOMAIN_OK, rt_tick_from_millisecond(10 * 1000), RT_EVENT_FLAG_OR) < 0)
             {
-                LOG_E("Domain resolve failed, wait dns result timeout.", socket);
+                //LOG_E("Domain resolve failed, wait dns result timeout.", socket);
+                LOG_E("Domain resolve failed, wait dns result timeout.");
                 result = -RT_ETIMEOUT;
                 continue;
             }


### PR DESCRIPTION
相关错误在 at_socket_ec20.c文件中第785行。
if (at_socket_event_recv(EC20_EVENT_DOMAIN_OK, rt_tick_from_millisecond(10 * 1000), RT_EVENT_FLAG_OR) < 0)
{
  //LOG_E("Domain resolve failed, wait dns result timeout.",  socket);
  LOG_E("Domain resolve failed, wait dns result timeout.");
  result = -RT_ETIMEOUT;
  continue;
} 发现这里打印的log日志并没有相关参数，请帮忙核对。已注释源代码。