### PR TITLE
1.修改发送函数中的返回值，确保返回的值是发送出去字节的总长度

### DIFF
--- a/class/ec20/at_socket_ec20.c
+++ b/class/ec20/at_socket_ec20.c
@@ -615,11 +615,7 @@ __exit:
         at_delete_resp(resp);
     }
         
-    if(result > 0){
-        result = sent_size;
-    }
-    
-    return result;
+    return result > 0 ? sent_size : result;
 }
 
 /**

--- a/class/ec20/at_socket_ec20.c
+++ b/class/ec20/at_socket_ec20.c
@@ -614,7 +614,11 @@ __exit:
     {
         at_delete_resp(resp);
     }
-
+        
+    if(result > 0){
+        result = sent_size;
+    }
+    
     return result;
 }
 

--- a/class/esp8266/at_socket_esp8266.c
+++ b/class/esp8266/at_socket_esp8266.c
@@ -292,11 +292,7 @@ __exit:
         at_delete_resp(resp);
     }
         
-    if(result > 0){
-        result = sent_size;
-    }
-
-    return result;
+    return result > 0 ? sent_size : result;
 }
 
 /**

--- a/class/esp8266/at_socket_esp8266.c
+++ b/class/esp8266/at_socket_esp8266.c
@@ -291,6 +291,10 @@ __exit:
     {
         at_delete_resp(resp);
     }
+        
+    if(result > 0){
+        result = sent_size;
+    }
 
     return result;
 }

--- a/class/m26/at_socket_m26.c
+++ b/class/m26/at_socket_m26.c
@@ -399,10 +399,7 @@ __exit:
         at_delete_resp(resp);
     }
     
-    if(result > 0){
-        result = sent_size;
-    }
-    return result;
+    return result > 0 ? sent_size : result;
 }
 
 /**

--- a/class/m26/at_socket_m26.c
+++ b/class/m26/at_socket_m26.c
@@ -398,7 +398,10 @@ __exit:
     {
         at_delete_resp(resp);
     }
-
+    
+    if(result > 0){
+        result = sent_size;
+    }
     return result;
 }
 

--- a/class/mw31/at_socket_mw31.c
+++ b/class/mw31/at_socket_mw31.c
@@ -263,11 +263,7 @@ __exit:
         at_delete_resp(resp);
     }
     
-    if(result > 0){
-        result = sent_size;
-    }
-
-    return result;
+    return result > 0 ? sent_size : result;
 }
 
 /**

--- a/class/mw31/at_socket_mw31.c
+++ b/class/mw31/at_socket_mw31.c
@@ -262,6 +262,10 @@ __exit:
     {
         at_delete_resp(resp);
     }
+    
+    if(result > 0){
+        result = sent_size;
+    }
 
     return result;
 }

--- a/class/rw007/at_socket_rw007.c
+++ b/class/rw007/at_socket_rw007.c
@@ -291,6 +291,10 @@ __exit:
     {
         at_delete_resp(resp);
     }
+       
+    if(result > 0){
+        result = sent_size;
+    }
 
     return result;
 }

--- a/class/rw007/at_socket_rw007.c
+++ b/class/rw007/at_socket_rw007.c
@@ -292,11 +292,7 @@ __exit:
         at_delete_resp(resp);
     }
        
-    if(result > 0){
-        result = sent_size;
-    }
-
-    return result;
+    return result > 0 ? sent_size : result;
 }
 
 /**

--- a/class/sim76xx/at_socket_sim76xx.c
+++ b/class/sim76xx/at_socket_sim76xx.c
@@ -483,6 +483,10 @@ __exit:
     {
         at_delete_resp(resp);
     }
+	
+    if(result > 0){
+        result = sent_size;
+    }
 
     return result;
 }

--- a/class/sim76xx/at_socket_sim76xx.c
+++ b/class/sim76xx/at_socket_sim76xx.c
@@ -484,11 +484,7 @@ __exit:
         at_delete_resp(resp);
     }
 	
-    if(result > 0){
-        result = sent_size;
-    }
-
-    return result;
+    return result > 0 ? sent_size : result;
 }
 
 /**

--- a/class/sim800c/at_socket_sim800c.c
+++ b/class/sim800c/at_socket_sim800c.c
@@ -340,6 +340,10 @@ __exit:
     {
         at_delete_resp(resp);
     }
+     
+    if(result > 0){
+        result = sent_size;
+    }
 
     return result;
 }

--- a/class/sim800c/at_socket_sim800c.c
+++ b/class/sim800c/at_socket_sim800c.c
@@ -341,11 +341,7 @@ __exit:
         at_delete_resp(resp);
     }
      
-    if(result > 0){
-        result = sent_size;
-    }
-
-    return result;
+    return result > 0 ? sent_size : result;
 }
 
 /**


### PR DESCRIPTION
当发送的字节数超过2048的时候，会发多次发送，但是最终返回的result是最后一次发送的长度，会导致调用者拿到的返回不等于包的长度，而引发调用者多次调用