### PR TITLE
air720 update And bc26 sleep mode fix

### DIFF
--- a/class/air720/at_device_air720.c
+++ b/class/air720/at_device_air720.c
@@ -491,18 +491,18 @@ static int air720_netdev_ping(struct netdev *netdev, const char *host,
         return -RT_ERROR;
     }
 
-    // for (i = 0; i < rt_strlen(host) && !isalpha(host[i]); i++)
-    //     ;
+    for (i = 0; i < rt_strlen(host) && !isalpha(host[i]); i++)
+        ;
 
-    // if (i < strlen(host))
-    // {
-    //     /* check domain name is usable */
-    //     if (air720_ping_domain_resolve(device, host, ip_addr) < 0)
-    //     {
-    //         return -RT_ERROR;
-    //     }
-    //     rt_memset(ip_addr, 0x00, air720_PING_IP_SIZE);
-    // }
+    if (i < strlen(host))
+    {
+        /* check domain name is usable */
+        if (air720_ping_domain_resolve(device, host, ip_addr) < 0)
+        {
+            return -RT_ERROR;
+        }
+        rt_memset(ip_addr, 0x00, air720_PING_IP_SIZE);
+    }
 
     resp = at_create_resp(air720_PING_RESP_SIZE, 0, air720_PING_TIMEO);
     if (resp == RT_NULL)
@@ -512,16 +512,16 @@ static int air720_netdev_ping(struct netdev *netdev, const char *host,
         goto __exit;
     }
 
-    // /* domain name prase error options */
-    // if (at_resp_parse_line_args_by_kw(resp, "+CDNSGIP: 0", "+CDNSGIP: 0,%d", &err_code) > 0)
-    // {
-    //     /* 3 - network error, 8 - dns common error */
-    //     if (err_code == 3 || err_code == 8)
-    //     {
-    //         result = -RT_ERROR;
-    //         goto __exit;
-    //     }
-    // }
+    /* domain name prase error options */
+    if (at_resp_parse_line_args_by_kw(resp, "+CDNSGIP: 0", "+CDNSGIP: 0,%d", &err_code) > 0)
+    {
+        /* 3 - network error, 8 - dns common error */
+        if (err_code == 3 || err_code == 8)
+        {
+            result = -RT_ERROR;
+            goto __exit;
+        }
+    }
 
     /* send "AT+CIPPING=<IP addr>[,<retryNum>[,<dataLen>[,<timeout>[,<ttl>]]]]" commond to send ping request */
     if (at_obj_exec_cmd(device->client, resp, "AT+CIPPING=%s,1,%d,%d,64",

--- a/class/air720/at_device_air720.c
+++ b/class/air720/at_device_air720.c
@@ -40,10 +40,6 @@
 #define AIR720_THREAD_STACK_SIZE 2048
 #define AIR720_THREAD_PRIORITY (RT_THREAD_PRIORITY_MAX / 2)
 // #define AIR720_THREAD_PRIORITY 6
-/* AT+CSTT command default*/
-static char *CSTT_CHINA_MOBILE = "AT+CSTT=\"CMNET\"";
-static char *CSTT_CHINA_UNICOM = "AT+CSTT=\"UNINET\"";
-static char *CSTT_CHINA_TELECOM = "AT+CSTT=\"CTNET\"";
 
 static void air720_power_on(struct at_device *device)
 {
@@ -57,16 +53,9 @@ static void air720_power_on(struct at_device *device)
     {
         return;
     }
-    if (rt_pin_read(air720->power_status_pin) == PIN_HIGH)
-    {
-        return;
-    }
-    rt_pin_write(air720->power_pin, PIN_HIGH);
-    while (rt_pin_read(air720->power_status_pin) == PIN_LOW)
-    {
-        rt_thread_mdelay(10);
-    }
     rt_pin_write(air720->power_pin, PIN_LOW);
+    rt_thread_mdelay(4000);
+    rt_pin_write(air720->power_pin, PIN_HIGH);
 }
 
 static void air720_power_off(struct at_device *device)
@@ -80,17 +69,9 @@ static void air720_power_off(struct at_device *device)
     {
         return;
     }
-    if (rt_pin_read(air720->power_status_pin) == PIN_LOW)
-    {
-        return;
-    }
-
-    rt_pin_write(air720->power_pin, PIN_HIGH);
-    while (rt_pin_read(air720->power_status_pin) == PIN_HIGH)
-    {
-        rt_thread_mdelay(10);
-    }
     rt_pin_write(air720->power_pin, PIN_LOW);
+    rt_thread_mdelay(2000);
+    rt_pin_write(air720->power_pin, PIN_HIGH);
 }
 
 /* =============================  sim76xx network interface operations ============================= */
@@ -134,17 +115,24 @@ static int air720_netdev_set_info(struct netdev *netdev)
         goto __exit;
     }
 
-    /* set network interface device hardware address(IEMI) */
+    /* set network interface device hardware address(IMEI) */
     {
 #define air720_NETDEV_HWADDR_LEN 8
 #define air720_IEMI_LEN 15
 
-        char iemi[air720_IEMI_LEN] = {0};
+        char imei[air720_IEMI_LEN] = {0};
         int i = 0, j = 0;
 
-        /* send "AT+GSN" commond to get device IEMI */
-        if (at_obj_exec_cmd(device->client, resp, "AT+GSN") < 0)
+        /* send "AT+CGSN" commond to get device IMEI */
+        if (at_obj_exec_cmd(device->client, resp, "AT+CGSN") < 0)
         {
+            result = -RT_ERROR;
+            goto __exit;
+        }
+
+        if (at_resp_parse_line_args(resp, 2, "%s", imei) <= 0)
+        {
+            LOG_E("%s device prase \"AT+CGSN\" cmd error.", device->name);
             result = -RT_ERROR;
             goto __exit;
         }
@@ -155,11 +143,11 @@ static int air720_netdev_set_info(struct netdev *netdev)
         {
             if (j != air720_IEMI_LEN - 1)
             {
-                netdev->hwaddr[i] = (iemi[j] - '0') * 10 + (iemi[j + 1] - '0');
+                netdev->hwaddr[i] = (imei[j] - '0') * 10 + (imei[j + 1] - '0');
             }
             else
             {
-                netdev->hwaddr[i] = (iemi[j] - '0');
+                netdev->hwaddr[i] = (imei[j] - '0');
             }
         }
     }
@@ -185,7 +173,7 @@ static int air720_netdev_set_info(struct netdev *netdev)
             goto __exit;
         }
 
-        LOG_E("air720 device(%s) IP address: %s", device->name, ipaddr);
+        LOG_I("air720 device(%s) IP address: %s", device->name, ipaddr);
 
         /* set network interface address information */
         inet_aton(ipaddr, &addr);
@@ -233,6 +221,8 @@ __exit:
     return result;
 }
 
+int air720_reboot(struct at_device *device);
+
 static void check_link_status_entry(void *parameter)
 {
 #define air720_LINK_STATUS_OK 1
@@ -247,7 +237,7 @@ static void check_link_status_entry(void *parameter)
 
     char parsed_data[10] = {0};
     struct netdev *netdev = (struct netdev *)parameter;
-    
+
     LOG_D("statrt air720 device(%s) link status check \n");
 
     device = at_device_get_by_name(AT_DEVICE_NAMETYPE_NETDEV, netdev->name);
@@ -280,7 +270,6 @@ static void check_link_status_entry(void *parameter)
         /* check the network interface device link status  */
         if ((air720_LINK_STATUS_OK == link_status) != netdev_is_link_up(netdev))
         {
-
             netdev_low_level_set_link_status(netdev, (air720_LINK_STATUS_OK == link_status));
         }
 
@@ -299,6 +288,7 @@ static void check_link_status_entry(void *parameter)
         {
             //LTE down
             LOG_E("the lte pin is low");
+            air720_reboot(device);
         }
 
         rt_thread_mdelay(air720_LINK_DELAY_TIME);
@@ -479,7 +469,7 @@ static int air720_netdev_ping(struct netdev *netdev, const char *host,
 {
 #define air720_PING_RESP_SIZE 128
 #define air720_PING_IP_SIZE 16
-#define air720_PING_TIMEO (5 * RT_TICK_PER_SECOND)
+#define air720_PING_TIMEO (10 * RT_TICK_PER_SECOND)
 
 #define air720_PING_ERR_TIME 600
 #define air720_PING_ERR_TTL 255
@@ -501,18 +491,18 @@ static int air720_netdev_ping(struct netdev *netdev, const char *host,
         return -RT_ERROR;
     }
 
-    for (i = 0; i < rt_strlen(host) && !isalpha(host[i]); i++)
-        ;
+    // for (i = 0; i < rt_strlen(host) && !isalpha(host[i]); i++)
+    //     ;
 
-    if (i < strlen(host))
-    {
-        /* check domain name is usable */
-        if (air720_ping_domain_resolve(device, host, ip_addr) < 0)
-        {
-            return -RT_ERROR;
-        }
-        rt_memset(ip_addr, 0x00, air720_PING_IP_SIZE);
-    }
+    // if (i < strlen(host))
+    // {
+    //     /* check domain name is usable */
+    //     if (air720_ping_domain_resolve(device, host, ip_addr) < 0)
+    //     {
+    //         return -RT_ERROR;
+    //     }
+    //     rt_memset(ip_addr, 0x00, air720_PING_IP_SIZE);
+    // }
 
     resp = at_create_resp(air720_PING_RESP_SIZE, 0, air720_PING_TIMEO);
     if (resp == RT_NULL)
@@ -522,16 +512,16 @@ static int air720_netdev_ping(struct netdev *netdev, const char *host,
         goto __exit;
     }
 
-    /* domain name prase error options */
-    if (at_resp_parse_line_args_by_kw(resp, "+CDNSGIP: 0", "+CDNSGIP: 0,%d", &err_code) > 0)
-    {
-        /* 3 - network error, 8 - dns common error */
-        if (err_code == 3 || err_code == 8)
-        {
-            result = -RT_ERROR;
-            goto __exit;
-        }
-    }
+    // /* domain name prase error options */
+    // if (at_resp_parse_line_args_by_kw(resp, "+CDNSGIP: 0", "+CDNSGIP: 0,%d", &err_code) > 0)
+    // {
+    //     /* 3 - network error, 8 - dns common error */
+    //     if (err_code == 3 || err_code == 8)
+    //     {
+    //         result = -RT_ERROR;
+    //         goto __exit;
+    //     }
+    // }
 
     /* send "AT+CIPPING=<IP addr>[,<retryNum>[,<dataLen>[,<timeout>[,<ttl>]]]]" commond to send ping request */
     if (at_obj_exec_cmd(device->client, resp, "AT+CIPPING=%s,1,%d,%d,64",
@@ -558,7 +548,7 @@ static int air720_netdev_ping(struct netdev *netdev, const char *host,
     inet_aton(ip_addr, &(ping_resp->ip_addr));
     ping_resp->data_len = data_len;
     /* reply time, in units of 100 ms */
-    ping_resp->ticks = time * 100;
+    ping_resp->ticks = time;
     ping_resp->ttl = ttl;
 
 __exit:
@@ -644,8 +634,10 @@ static void air720_init_thread_entry(void *parameter)
 #define CSQ_RETRY 10
 #define CREG_RETRY 10
 #define CGREG_RETRY 30
+#define CGATT_RETRY 10
 
     int i, qimux, retry_num = INIT_RETRY;
+
     char parsed_data[10] = {0};
     rt_err_t result = RT_EOK;
     at_response_t resp = RT_NULL;
@@ -681,7 +673,7 @@ static void air720_init_thread_entry(void *parameter)
         /* show module version */
         for (i = 0; i < (int)resp->line_counts - 1; i++)
         {
-            LOG_E("%s", at_resp_get_line(resp, i + 1));
+            LOG_I("%s", at_resp_get_line(resp, i + 1));
         }
         /* check SIM card */
         for (i = 0; i < CPIN_RETRY; i++)
@@ -690,10 +682,10 @@ static void air720_init_thread_entry(void *parameter)
 
             if (at_resp_get_line_by_kw(resp, "READY"))
             {
-                LOG_E("air720 device(%s) SIM card detection success.", device->name);
+                LOG_I("air720 device(%s) SIM card detection success.", device->name);
                 break;
             }
-            rt_thread_mdelay(1000);
+            rt_thread_mdelay(500);
         }
         if (i == CPIN_RETRY)
         {
@@ -702,7 +694,7 @@ static void air720_init_thread_entry(void *parameter)
             goto __exit;
         }
         /* waiting for dirty data to be digested */
-        rt_thread_mdelay(10);
+        rt_thread_mdelay(100);
 
         /* check the GSM network is registered */
         for (i = 0; i < CREG_RETRY; i++)
@@ -712,7 +704,7 @@ static void air720_init_thread_entry(void *parameter)
             if (!strncmp(parsed_data, "0,1", sizeof(parsed_data)) ||
                 !strncmp(parsed_data, "0,5", sizeof(parsed_data)))
             {
-                LOG_E("air720 device(%s) GSM network is registered(%s),", device->name, parsed_data);
+                LOG_I("air720 device(%s) GSM network is registered(%s),", device->name, parsed_data);
                 break;
             }
             rt_thread_mdelay(1000);
@@ -731,7 +723,7 @@ static void air720_init_thread_entry(void *parameter)
             if (!strncmp(parsed_data, "0,1", sizeof(parsed_data)) ||
                 !strncmp(parsed_data, "0,5", sizeof(parsed_data)))
             {
-                LOG_E("air720 device(%s) GPRS network is registered(%s).", device->name, parsed_data);
+                LOG_I("air720 device(%s) GPRS network is registered(%s).", device->name, parsed_data);
                 break;
             }
             rt_thread_mdelay(1000);
@@ -750,7 +742,7 @@ static void air720_init_thread_entry(void *parameter)
             at_resp_parse_line_args_by_kw(resp, "+CSQ:", "+CSQ: %s", &parsed_data);
             if (strncmp(parsed_data, "99,99", sizeof(parsed_data)))
             {
-                LOG_E("air720 device(%s) signal strength: %s", device->name, parsed_data);
+                LOG_I("air720 device(%s) signal strength: %s", device->name, parsed_data);
                 break;
             }
             rt_thread_mdelay(1000);
@@ -762,8 +754,26 @@ static void air720_init_thread_entry(void *parameter)
             goto __exit;
         }
 
+        for (i = 0; i < CGATT_RETRY; i++)
+        {
+            AT_SEND_CMD(client, resp, 0, 300, "AT+CGATT?");
+            at_resp_parse_line_args_by_kw(resp, "+CGATT:", "+CGATT: %s", &parsed_data);
+            if (strncmp(parsed_data, "1", sizeof(parsed_data)) == 0)
+            {
+                LOG_I("air720 device(%s) attach GPRS", device->name);
+                break;
+            }
+            rt_thread_mdelay(1000);
+        }
+        if (i == CGATT_RETRY)
+        {
+            LOG_E("air720 device(%s) can't attach GPRS ", device->name);
+            result = -RT_ERROR;
+            goto __exit;
+        }
+
         /* the device default response timeout is 40 seconds, but it set to 15 seconds is convenient to use. */
-        AT_SEND_CMD(client, resp, 2, 20 * 1000, "AT+CIPSHUT");
+        AT_SEND_CMD(client, resp, 2, 2 * 1000, "AT+CIPSHUT");
 
         /* Set to multiple connections */
         AT_SEND_CMD(client, resp, 0, 300, "AT+CIPMUX?");
@@ -773,35 +783,14 @@ static void air720_init_thread_entry(void *parameter)
             AT_SEND_CMD(client, resp, 0, 300, "AT+CIPMUX=1");
         }
 
-        // AT_SEND_CMD(client, resp, 0, 300, CSTT_CHINA_MOBILE);
+        AT_SEND_CMD(client, resp, 0, 300, "AT+CIPQSEND=1"); //fast send mode ,recommend
 
-        AT_SEND_CMD(client, resp, 0, 300, "AT+COPS=3,0");
-        AT_SEND_CMD(client, resp, 0, 300, "AT+COPS?");
-        at_resp_parse_line_args_by_kw(resp, "+COPS:", "+COPS: %*[^\"]\"%[^\"]", &parsed_data);
+        AT_SEND_CMD(client, resp, 0, 300, "AT+CSTT");
 
-        if (rt_strcmp(parsed_data, "CHINA MOBILE") == 0)
-        {
-            /* "CMCC" */
-            LOG_E("air720 device(%s) network operator: %s", device->name, parsed_data);
-            AT_SEND_CMD(client, resp, 0, 300, CSTT_CHINA_MOBILE);
-        }
-        else if (rt_strcmp(parsed_data, "CHN-UNICOM") == 0)
-        {
-            /* "UNICOM" */
-            LOG_E("air720 device(%s) network operator: %s", device->name, parsed_data);
-            AT_SEND_CMD(client, resp, 0, 300, CSTT_CHINA_UNICOM);
-        }
-        else if (rt_strcmp(parsed_data, "CHINA TELECOM") == 0)
-        {
-            AT_SEND_CMD(client, resp, 0, 300, CSTT_CHINA_TELECOM);
-            /* "CT" */
-            LOG_E("air720 device(%s) network operator: %s", device->name, parsed_data);
-        }
-        //client = device->client;
-        /* the device default response timeout is 150 seconds, but it set to 20 seconds is convenient to use. */
         AT_SEND_CMD(client, resp, 0, 20 * 1000, "AT+CIICR");
 
         AT_SEND_CMD(client, resp, 2, 300, "AT+CIFSR");
+
         if (at_resp_get_line_by_kw(resp, "ERROR") != RT_NULL)
         {
             LOG_E("air720 device(%s) get the local address failed.", device->name);
@@ -833,8 +822,13 @@ static void air720_init_thread_entry(void *parameter)
     if (result == RT_EOK)
     {
         /* set network interface device status and address information */
-        air720_netdev_set_info(device->netdev); 
-        air720_netdev_check_link_status(device->netdev);
+        air720_netdev_set_info(device->netdev);
+
+        if (rt_thread_find(device->netdev->name) == RT_NULL)
+        {
+            air720_netdev_check_link_status(device->netdev);
+        }
+
         LOG_I("air720 device(%s) network initialize success!", device->name);
     }
     else
@@ -926,6 +920,17 @@ static int air720_deinit(struct at_device *device)
     return air720_netdev_set_down(device->netdev);
 }
 
+static int air720_reboot(struct at_device *device)
+{
+    air720_power_off(device);
+    rt_thread_mdelay(2000);
+    air720_power_on(device);
+    device->is_init = RT_FALSE;
+    air720_net_init(device);
+    device->is_init = RT_TRUE;
+    return RT_EOK;
+}
+
 static int air720_reset(struct at_device *device)
 {
     int result = RT_EOK;
@@ -973,6 +978,9 @@ static int air720_control(struct at_device *device, int cmd, void *arg)
         break;
     case AT_DEVICE_CTRL_RESET:
         result = air720_reset(device);
+        break;
+    case AT_DEVICE_CTRL_REBOOT:
+        result = air720_reboot(device);
         break;
     default:
         LOG_E("input error control command(%d).", cmd);

--- a/class/air720/at_socket_air720.c
+++ b/class/air720/at_socket_air720.c
@@ -337,10 +337,6 @@ __exit:
     return result;
 }
 
-static int air720_socket_quick_send(struct at_socket *socket, const char *buff, size_t bfsz, enum at_socket_type type)
-{
-}
-
 /**
  * domain resolve by AT commands.
  *

--- a/class/air720/at_socket_air720.c
+++ b/class/air720/at_socket_air720.c
@@ -27,7 +27,6 @@
 #include <string.h>
 #include <at_device_air720.h>
 
-
 #if !defined(AT_SW_VERSION_NUM) || AT_SW_VERSION_NUM < 0x10300
 #error "This AT Client version is older, please check and update latest AT Client!"
 #endif
@@ -137,7 +136,7 @@ static int air720_socket_connect(struct at_socket *socket, char *ip, int32_t por
 
     RT_ASSERT(ip);
     RT_ASSERT(port >= 0);
-    
+
     resp = at_create_resp(128, 0, 5 * RT_TICK_PER_SECOND);
     if (resp == RT_NULL)
     {
@@ -225,7 +224,6 @@ __exit:
 
     if (result != RT_EOK)
     {
-        
     }
 
     return result;
@@ -337,6 +335,10 @@ __exit:
     }
 
     return result;
+}
+
+static int air720_socket_quick_send(struct at_socket *socket, const char *buff, size_t bfsz, enum at_socket_type type)
+{
 }
 
 /**
@@ -549,8 +551,10 @@ static void urc_recv_func(struct at_client *client, const char *data, rt_size_t 
 
     RT_ASSERT(data && size);
 
+    //LOG_I("get +receive data %s", data);
     /* get the current socket and receive buffer size by receive data */
-    sscanf(data, "+RECEIVE,%d,%d:", &device_socket, (int *)&bfsz);
+    sscanf(data, "%*[^,],%d,%d:", &device_socket, (int *)&bfsz);
+    // sscanf(data, "+RECEIVE,%d,%d:", &device_socket, (int *)&bfsz);
     /* get receive timeout by receive buffer length */
     timeout = bfsz;
 
@@ -604,6 +608,32 @@ static void urc_recv_func(struct at_client *client, const char *data, rt_size_t 
     }
 }
 
+static void urc_dataaccept_func(struct at_client *client, const char *data, rt_size_t size)
+{
+
+    RT_ASSERT(data && size);
+
+    int device_socket = 0;
+    rt_size_t bfsz = 0;
+    struct at_device *device = RT_NULL;
+    char *client_name = client->device->parent.name;
+
+    RT_ASSERT(data && size);
+
+    device = at_device_get_by_name(AT_DEVICE_NAMETYPE_CLIENT, client_name);
+    if (device == RT_NULL)
+    {
+        LOG_E("get air720 device by client name(%s) failed.", client_name);
+        return;
+    }
+
+    /* get the current socket by receive data */
+    sscanf(data, "%*[^:],%d,%d:", &device_socket, (int *)&bfsz);
+
+    air720_socket_event_send(device, SET_EVENT(device_socket, AIR720_EVENT_SEND_OK));
+}
+
+//DATA ACCEPT:
 /* air720 device URC table for the socket data */
 static const struct at_urc urc_table[] =
     {
@@ -613,7 +643,9 @@ static const struct at_urc urc_table[] =
         {"", ", SEND FAIL\r\n", urc_send_func},
         {"", ", CLOSE OK\r\n", urc_close_func},
         {"", ", CLOSED\r\n", urc_close_func},
+        {"ECEIVE,", "\r\n", urc_recv_func},
         {"+RECEIVE,", "\r\n", urc_recv_func},
+        {"DATA ACCEPT:", "\r\n", urc_dataaccept_func},
 };
 
 static const struct at_socket_ops air720_socket_ops =
@@ -621,7 +653,7 @@ static const struct at_socket_ops air720_socket_ops =
         air720_socket_connect,
         air720_socket_close,
         air720_socket_send,
-        air720_domain_resolve, 
+        air720_domain_resolve,
         air720_socket_set_event_cb,
 };
 

--- a/class/bc26/at_device_bc26.c
+++ b/class/bc26/at_device_bc26.c
@@ -165,6 +165,7 @@ static int bc26_wakeup(struct at_device *device)
         rt_thread_mdelay(100);
         rt_pin_write(bc26->power_pin, PIN_LOW);
         rt_thread_mdelay(200);
+		rt_pin_write(bc26->power_pin, PIN_HIGH);
     }
     
     /* disable sleep mode */
@@ -209,6 +210,7 @@ static int bc26_check_link_status(struct at_device *device)
             rt_thread_mdelay(100);
             rt_pin_write(bc26->power_pin, PIN_LOW);
             rt_thread_mdelay(200);
+			rt_pin_write(bc26->power_pin, PIN_HIGH);
         }
     }
     

--- a/class/bc26/at_device_bc26.c
+++ b/class/bc26/at_device_bc26.c
@@ -27,136 +27,136 @@
 
 #include <at_device_bc26.h>
 
-#define LOG_TAG                         "at.dev.bc26"
+#define LOG_TAG "at.dev.bc26"
 #include <at_log.h>
 
 #ifdef AT_DEVICE_USING_BC26
 
-#define BC26_WAIT_CONNECT_TIME          5000
-#define BC26_THREAD_STACK_SIZE          2048
-#define BC26_THREAD_PRIORITY            (RT_THREAD_PRIORITY_MAX/2)
+#define BC26_WAIT_CONNECT_TIME 5000
+#define BC26_THREAD_STACK_SIZE 2048
+#define BC26_THREAD_PRIORITY (RT_THREAD_PRIORITY_MAX / 2)
 
 static int bc26_power_on(struct at_device *device)
 {
     struct at_device_bc26 *bc26 = RT_NULL;
-    
+
     bc26 = (struct at_device_bc26 *)device->user_data;
     bc26->power_status = RT_TRUE;
 
     /* not nead to set pin configuration for bc26 device power on */
     if (bc26->power_pin == -1)
     {
-        return(RT_EOK);
+        return (RT_EOK);
     }
-    
+
     rt_pin_write(bc26->power_pin, PIN_HIGH);
     rt_thread_mdelay(500);
     rt_pin_write(bc26->power_pin, PIN_LOW);
 
-    return(RT_EOK);
+    return (RT_EOK);
 }
 
 static int bc26_power_off(struct at_device *device)
 {
     at_response_t resp = RT_NULL;
     struct at_device_bc26 *bc26 = RT_NULL;
-    
+
     resp = at_create_resp(64, 0, rt_tick_from_millisecond(300));
     if (resp == RT_NULL)
     {
         LOG_D("no memory for resp create.");
-        return(-RT_ERROR);
+        return (-RT_ERROR);
     }
-    
+
     if (at_obj_exec_cmd(device->client, resp, "AT+QPOWD=0") != RT_EOK)
     {
         LOG_D("power off fail.");
         at_delete_resp(resp);
-        return(-RT_ERROR);
+        return (-RT_ERROR);
     }
-    
+
     at_delete_resp(resp);
-    
+
     bc26 = (struct at_device_bc26 *)device->user_data;
     bc26->power_status = RT_FALSE;
-    
-    return(RT_EOK);
+
+    return (RT_EOK);
 }
 
 static int bc26_sleep(struct at_device *device)
 {
     at_response_t resp = RT_NULL;
     struct at_device_bc26 *bc26 = RT_NULL;
-    
+
     bc26 = (struct at_device_bc26 *)device->user_data;
-    if ( ! bc26->power_status)//power off
+    if (!bc26->power_status) //power off
     {
-        return(RT_EOK);
+        return (RT_EOK);
     }
-    if (bc26->sleep_status)//is sleep status 
+    if (bc26->sleep_status) //is sleep status
     {
-        return(RT_EOK);
+        return (RT_EOK);
     }
-    
+
     resp = at_create_resp(64, 0, rt_tick_from_millisecond(300));
     if (resp == RT_NULL)
     {
         LOG_D("no memory for resp create.");
-        return(-RT_ERROR);
+        return (-RT_ERROR);
     }
 
     /* enable sleep mode */
     if (at_obj_exec_cmd(device->client, resp, "AT+QSCLK=1") != RT_EOK)
-        
+
     {
         LOG_D("enable sleep fail.\"AT+QSCLK=1\" execute fail.");
         at_delete_resp(resp);
-        return(-RT_ERROR);
+        return (-RT_ERROR);
     }
-    
+
     /* enable PSM mode */
     if (at_obj_exec_cmd(device->client, resp, "AT+CPSMS=1,,,\"01000011\",\"00000001\"") != RT_EOK)
-        
+
     {
         LOG_D("enable sleep fail.\"AT+CPSMS=1...\" execute fail.");
         at_delete_resp(resp);
-        return(-RT_ERROR);
+        return (-RT_ERROR);
     }
 
     if (at_obj_exec_cmd(device->client, resp, "AT+QRELLOCK") != RT_EOK)
     {
         LOG_D("startup entry into sleep fail.");
         at_delete_resp(resp);
-        return(-RT_ERROR);
+        return (-RT_ERROR);
     }
-    
+
     bc26->sleep_status = RT_TRUE;
-    
+
     at_delete_resp(resp);
-    return(RT_EOK);
+    return (RT_EOK);
 }
 
 static int bc26_wakeup(struct at_device *device)
 {
     at_response_t resp = RT_NULL;
     struct at_device_bc26 *bc26 = RT_NULL;
-    
+
     bc26 = (struct at_device_bc26 *)device->user_data;
-    if ( ! bc26->power_status)//power off
+    if (!bc26->power_status) //power off
     {
         LOG_E("the power is off and the wake-up cannot be performed");
-        return(-RT_ERROR);
+        return (-RT_ERROR);
     }
-    if ( ! bc26->sleep_status)//no sleep status
+    if (!bc26->sleep_status) //no sleep status
     {
-        return(RT_EOK);
+        return (RT_EOK);
     }
-    
+
     resp = at_create_resp(64, 0, rt_tick_from_millisecond(300));
     if (resp == RT_NULL)
     {
         LOG_D("no memory for resp create.");
-        return(-RT_ERROR);
+        return (-RT_ERROR);
     }
 
     if (bc26->power_pin != -1)
@@ -165,29 +165,29 @@ static int bc26_wakeup(struct at_device *device)
         rt_thread_mdelay(100);
         rt_pin_write(bc26->power_pin, PIN_LOW);
         rt_thread_mdelay(200);
-		rt_pin_write(bc26->power_pin, PIN_HIGH);
+        rt_pin_write(bc26->power_pin, PIN_HIGH);
     }
-    
+
     /* disable sleep mode */
     if (at_obj_exec_cmd(device->client, resp, "AT+QSCLK=0") != RT_EOK)
     {
         LOG_D("wake up fail. \"AT+QSCLK=0\" execute fail.");
         at_delete_resp(resp);
-        return(-RT_ERROR);
+        return (-RT_ERROR);
     }
-    
+
     /* disable PSM mode  */
     if (at_obj_exec_cmd(device->client, resp, "AT+CPSMS=0") != RT_EOK)
     {
         LOG_D("wake up fail.\"AT+CPSMS=0\" execute fail.");
         at_delete_resp(resp);
-        return(-RT_ERROR);
+        return (-RT_ERROR);
     }
-    
+
     bc26->sleep_status = RT_FALSE;
-    
+
     at_delete_resp(resp);
-    return(RT_EOK);
+    return (RT_EOK);
 }
 
 static int bc26_check_link_status(struct at_device *device)
@@ -195,14 +195,14 @@ static int bc26_check_link_status(struct at_device *device)
     at_response_t resp = RT_NULL;
     struct at_device_bc26 *bc26 = RT_NULL;
     int result = -RT_ERROR;
-    
+
     bc26 = (struct at_device_bc26 *)device->user_data;
-    if ( ! bc26->power_status)//power off
+    if (!bc26->power_status) //power off
     {
         LOG_D("the power is off.");
-        return(-RT_ERROR);
+        return (-RT_ERROR);
     }
-    if (bc26->sleep_status)//is sleep status
+    if (bc26->sleep_status) //is sleep status
     {
         if (bc26->power_pin != -1)
         {
@@ -210,15 +210,15 @@ static int bc26_check_link_status(struct at_device *device)
             rt_thread_mdelay(100);
             rt_pin_write(bc26->power_pin, PIN_LOW);
             rt_thread_mdelay(200);
-			rt_pin_write(bc26->power_pin, PIN_HIGH);
+            rt_pin_write(bc26->power_pin, PIN_HIGH);
         }
     }
-    
+
     resp = at_create_resp(64, 0, rt_tick_from_millisecond(300));
     if (resp == RT_NULL)
     {
         LOG_D("no memory for resp create.");
-        return(-RT_ERROR);
+        return (-RT_ERROR);
     }
 
     result = -RT_ERROR;
@@ -234,26 +234,25 @@ static int bc26_check_link_status(struct at_device *device)
         }
     }
 
-    if (bc26->sleep_status)//is sleep status
+    if (bc26->sleep_status) //is sleep status
     {
         if (at_obj_exec_cmd(device->client, resp, "AT+QRELLOCK") != RT_EOK)
         {
             LOG_D("startup entry into sleep fail.");
         }
     }
-    
-    at_delete_resp(resp);
-    
-    return(result);
-}
 
+    at_delete_resp(resp);
+
+    return (result);
+}
 
 /* =============================  bc26 network interface operations ============================= */
 /* set bc26 network interface device status and address information */
 static int bc26_netdev_set_info(struct netdev *netdev)
 {
-#define BC26_INFO_RESP_SIZE      128
-#define BC26_INFO_RESP_TIMO      rt_tick_from_millisecond(300)
+#define BC26_INFO_RESP_SIZE 128
+#define BC26_INFO_RESP_TIMO rt_tick_from_millisecond(300)
 
     int result = RT_EOK;
     ip_addr_t addr;
@@ -284,8 +283,8 @@ static int bc26_netdev_set_info(struct netdev *netdev)
 
     /* set network interface device hardware address(IMEI) */
     {
-        #define BC26_NETDEV_HWADDR_LEN   8
-        #define BC26_IMEI_LEN            15
+#define BC26_NETDEV_HWADDR_LEN 8
+#define BC26_IMEI_LEN 15
 
         char imei[BC26_IMEI_LEN] = {0};
         int i = 0, j = 0;
@@ -296,19 +295,19 @@ static int bc26_netdev_set_info(struct netdev *netdev)
             result = -RT_ERROR;
             goto __exit;
         }
-        
+
         if (at_resp_parse_line_args(resp, 2, "%s", imei) <= 0)
         {
             LOG_E("%s device prase \"AT+GSN\" cmd error.", device->name);
             result = -RT_ERROR;
             goto __exit;
         }
-        
+
         LOG_D("%s device IMEI number: %s", device->name, imei);
 
         netdev->hwaddr_len = BC26_NETDEV_HWADDR_LEN;
         /* get hardware address by IMEI */
-        for (i = 0, j = 0; i < BC26_NETDEV_HWADDR_LEN && j < BC26_IMEI_LEN; i++, j+=2)
+        for (i = 0, j = 0; i < BC26_NETDEV_HWADDR_LEN && j < BC26_IMEI_LEN; i++, j += 2)
         {
             if (j != BC26_IMEI_LEN - 1)
             {
@@ -323,9 +322,9 @@ static int bc26_netdev_set_info(struct netdev *netdev)
 
     /* set network interface device IP address */
     {
-        #define IP_ADDR_SIZE_MAX    16
+#define IP_ADDR_SIZE_MAX 16
         char ipaddr[IP_ADDR_SIZE_MAX] = {0};
-        
+
         /* send "AT+CGPADDR=1" commond to get IP address */
         if (at_obj_exec_cmd(device->client, resp, "AT+CGPADDR=1") != RT_EOK)
         {
@@ -350,9 +349,9 @@ static int bc26_netdev_set_info(struct netdev *netdev)
 
     /* set network interface device dns server */
     {
-        #define DNS_ADDR_SIZE_MAX   16
+#define DNS_ADDR_SIZE_MAX 16
         char dns_server1[DNS_ADDR_SIZE_MAX] = {0}, dns_server2[DNS_ADDR_SIZE_MAX] = {0};
-        
+
         /* send "AT+QIDNSCFG=1" commond to get DNS servers address */
         if (at_obj_exec_cmd(device->client, resp, "AT+QIDNSCFG=1") != RT_EOK)
         {
@@ -362,7 +361,7 @@ static int bc26_netdev_set_info(struct netdev *netdev)
 
         /* parse response data "+QIDNSCFG: <contextID>,<pridnsaddr>,<secdnsaddr>" */
         if (at_resp_parse_line_args_by_kw(resp, "+QIDNSCFG:", "+QIDNSCFG: 1,\"%[^\"]\",\"%[^\"]\"",
-                dns_server1, dns_server2) <= 0)
+                                          dns_server1, dns_server2) <= 0)
         {
             LOG_E("%s device prase \"AT+QIDNSCFG=1\" cmd error.", device->name);
             result = -RT_ERROR;
@@ -390,11 +389,11 @@ __exit:
 
 static void bc26_check_link_status_entry(void *parameter)
 {
-#define BC26_LINK_DELAY_TIME    (60 * RT_TICK_PER_SECOND)
+#define BC26_LINK_DELAY_TIME (60 * RT_TICK_PER_SECOND)
 
     rt_bool_t is_link_up;
     struct at_device *device = RT_NULL;
-    struct netdev *netdev = (struct netdev *) parameter;
+    struct netdev *netdev = (struct netdev *)parameter;
 
     device = at_device_get_by_name(AT_DEVICE_NAMETYPE_NETDEV, netdev->name);
     if (device == RT_NULL)
@@ -402,7 +401,7 @@ static void bc26_check_link_status_entry(void *parameter)
         LOG_E("get device(%s) failed.", netdev->name);
         return;
     }
-    
+
     while (1)
     {
         is_link_up = (bc26_check_link_status(device) == RT_EOK);
@@ -415,9 +414,9 @@ static void bc26_check_link_status_entry(void *parameter)
 
 static int bc26_netdev_check_link_status(struct netdev *netdev)
 {
-#define BC26_LINK_THREAD_TICK           20
-#define BC26_LINK_THREAD_STACK_SIZE     (1024 + 512)
-#define BC26_LINK_THREAD_PRIORITY       (RT_THREAD_PRIORITY_MAX - 2)
+#define BC26_LINK_THREAD_TICK 20
+#define BC26_LINK_THREAD_STACK_SIZE (1024 + 512)
+#define BC26_LINK_THREAD_PRIORITY (RT_THREAD_PRIORITY_MAX - 2)
 
     rt_thread_t tid;
     char tname[RT_NAME_MAX] = {0};
@@ -487,8 +486,8 @@ static int bc26_netdev_set_down(struct netdev *netdev)
 
 static int bc26_netdev_set_dns_server(struct netdev *netdev, uint8_t dns_num, ip_addr_t *dns_server)
 {
-#define BC26_DNS_RESP_LEN    64
-#define BC26_DNS_RESP_TIMEO  rt_tick_from_millisecond(300)
+#define BC26_DNS_RESP_LEN 64
+#define BC26_DNS_RESP_TIMEO rt_tick_from_millisecond(300)
 
     int result = RT_EOK;
     at_response_t resp = RT_NULL;
@@ -513,8 +512,8 @@ static int bc26_netdev_set_dns_server(struct netdev *netdev, uint8_t dns_num, ip
     }
 
     /* send "AT+QIDNSCFG=<pri_dns>[,<sec_dns>]" commond to set dns servers */
-    if (at_obj_exec_cmd(device->client, resp, "AT+QIDNSCFG=%d,%s", 
-        dns_num, inet_ntoa(*dns_server)) != RT_EOK)
+    if (at_obj_exec_cmd(device->client, resp, "AT+QIDNSCFG=%d,%s",
+                        dns_num, inet_ntoa(*dns_server)) != RT_EOK)
     {
         result = -RT_ERROR;
         goto __exit;
@@ -533,11 +532,11 @@ __exit:
 
 #ifdef NETDEV_USING_PING
 static int bc26_netdev_ping(struct netdev *netdev, const char *host,
-        size_t data_len, uint32_t timeout, struct netdev_ping_resp *ping_resp)
+                            size_t data_len, uint32_t timeout, struct netdev_ping_resp *ping_resp)
 {
-#define BC26_PING_RESP_SIZE       128
-#define BC26_PING_IP_SIZE         16
-#define BC26_PING_TIMEO           (5 * RT_TICK_PER_SECOND)
+#define BC26_PING_RESP_SIZE 128
+#define BC26_PING_IP_SIZE 16
+#define BC26_PING_TIMEO (5 * RT_TICK_PER_SECOND)
 
     rt_err_t result = RT_EOK;
     int response = -1, recv_data_len, ping_time, ttl;
@@ -610,33 +609,31 @@ __exit:
 }
 #endif /* NETDEV_USING_PING */
 
-
-
 const struct netdev_ops bc26_netdev_ops =
-{
-    bc26_netdev_set_up,
-    bc26_netdev_set_down,
+    {
+        bc26_netdev_set_up,
+        bc26_netdev_set_down,
 
-    RT_NULL,
-    bc26_netdev_set_dns_server,
-    RT_NULL,
+        RT_NULL,
+        bc26_netdev_set_dns_server,
+        RT_NULL,
 
 #ifdef NETDEV_USING_PING
-    bc26_netdev_ping,
+        bc26_netdev_ping,
 #endif
-    RT_NULL,
+        RT_NULL,
 };
 
 static struct netdev *bc26_netdev_add(const char *netdev_name)
 {
-#define ETHERNET_MTU        1500
-#define HWADDR_LEN          8
+#define ETHERNET_MTU 1500
+#define HWADDR_LEN 8
     struct netdev *netdev = RT_NULL;
 
     netdev = netdev_get_by_name(netdev_name);
-    if(netdev != RT_NULL)
+    if (netdev != RT_NULL)
     {
-        return(netdev);
+        return (netdev);
     }
 
     netdev = (struct netdev *)rt_calloc(1, sizeof(struct netdev));
@@ -651,7 +648,7 @@ static struct netdev *bc26_netdev_add(const char *netdev_name)
     netdev->hwaddr_len = HWADDR_LEN;
 
 #ifdef SAL_USING_AT
-    extern int sal_at_netdev_set_pf_info(struct netdev *netdev);
+    extern int sal_at_netdev_set_pf_info(struct netdev * netdev);
     /* set the network interface socket/netdb operations */
     sal_at_netdev_set_pf_info(netdev);
 #endif
@@ -666,17 +663,17 @@ static struct netdev *bc26_netdev_add(const char *netdev_name)
 /* initialize for bc26 */
 static void bc26_init_thread_entry(void *parameter)
 {
-#define INIT_RETRY                     5
-#define CPIN_RETRY                     5
-#define CSQ_RETRY                      20
-#define CGREG_RETRY                    50
-#define IPADDR_RETRY                   10
+#define INIT_RETRY 5
+#define CPIN_RETRY 5
+#define CSQ_RETRY 20
+#define CGREG_RETRY 50
+#define IPADDR_RETRY 10
 
     int i;
     int retry_num = INIT_RETRY;
     rt_err_t result = RT_EOK;
     at_response_t resp = RT_NULL;
-    struct at_device *device = (struct at_device *) parameter;
+    struct at_device *device = (struct at_device *)parameter;
     struct at_client *client = device->client;
 
     resp = at_create_resp(128, 0, rt_tick_from_millisecond(300));
@@ -700,14 +697,14 @@ static void bc26_init_thread_entry(void *parameter)
             result = -RT_ETIMEOUT;
             goto __exit;
         }
-        
+
         /* disable echo */
         if (at_obj_exec_cmd(device->client, resp, "ATE0") != RT_EOK)
         {
             result = -RT_ERROR;
             goto __exit;
         }
-        
+
         /* disable sleep mode  */
         if (at_obj_exec_cmd(device->client, resp, "AT+QSCLK=0") != RT_EOK)
         {
@@ -721,14 +718,14 @@ static void bc26_init_thread_entry(void *parameter)
             result = -RT_ERROR;
             goto __exit;
         }
-        
+
         /* disable PSM mode  */
         if (at_obj_exec_cmd(device->client, resp, "AT+CPSMS=0") != RT_EOK)
         {
             result = -RT_ERROR;
             goto __exit;
         }
-        
+
         /* Get the baudrate */
         if (at_obj_exec_cmd(device->client, resp, "AT+IPR?") != RT_EOK)
         {
@@ -736,19 +733,19 @@ static void bc26_init_thread_entry(void *parameter)
             goto __exit;
         }
         at_resp_parse_line_args_by_kw(resp, "+IPR:", "+IPR: %d", &i);
-        LOG_D("%s device baudrate %d", device->name, i);     
-        
+        LOG_D("%s device baudrate %d", device->name, i);
+
         /* get module version */
         if (at_obj_exec_cmd(device->client, resp, "ATI") != RT_EOK)
         {
             result = -RT_ERROR;
             goto __exit;
         }
-        for (i = 0; i < (int) resp->line_counts - 1; i++)
+        for (i = 0; i < (int)resp->line_counts - 1; i++)
         {
             LOG_D("%s", at_resp_get_line(resp, i + 1));
         }
-        
+
         /* check SIM card */
         for (i = 0; i < CPIN_RETRY; i++)
         {
@@ -773,13 +770,13 @@ static void bc26_init_thread_entry(void *parameter)
             if (at_obj_exec_cmd(device->client, resp, "AT+CSQ") == RT_EOK)
             {
                 int signal_strength = 0, err_rate = 0;
-                
+
                 if (at_resp_parse_line_args_by_kw(resp, "+CSQ:", "+CSQ: %d,%d", &signal_strength, &err_rate) > 0)
                 {
                     if ((signal_strength != 99) && (signal_strength != 0))
                     {
                         LOG_D("%s device signal strength: %d, channel bit error rate: %d",
-                                device->name, signal_strength, err_rate);
+                              device->name, signal_strength, err_rate);
                         break;
                     }
                 }
@@ -791,7 +788,7 @@ static void bc26_init_thread_entry(void *parameter)
             result = -RT_ERROR;
             goto __exit;
         }
-                
+
         /* check the GPRS network is registered */
         for (i = 0; i < CGREG_RETRY; i++)
         {
@@ -799,7 +796,7 @@ static void bc26_init_thread_entry(void *parameter)
             if (at_obj_exec_cmd(device->client, resp, "AT+CGREG?") == RT_EOK)
             {
                 int link_stat = 0;
-                
+
                 if (at_resp_parse_line_args_by_kw(resp, "+CGREG:", "+CGREG: %*d,%d", &link_stat) > 0)
                 {
                     if ((link_stat == 1) || (link_stat == 5))
@@ -816,16 +813,16 @@ static void bc26_init_thread_entry(void *parameter)
             result = -RT_ERROR;
             goto __exit;
         }
-        
+
         /* check the GPRS network IP address */
         for (i = 0; i < IPADDR_RETRY; i++)
         {
             rt_thread_mdelay(1000);
             if (at_obj_exec_cmd(device->client, resp, "AT+CGPADDR=1") == RT_EOK)
             {
-                #define IP_ADDR_SIZE_MAX    16
+#define IP_ADDR_SIZE_MAX 16
                 char ipaddr[IP_ADDR_SIZE_MAX] = {0};
-                
+
                 /* parse response data "+CGPADDR: 1,<IP_address>" */
                 if (at_resp_parse_line_args_by_kw(resp, "+CGPADDR:", "+CGPADDR: %*d,%s", ipaddr) > 0)
                 {
@@ -840,7 +837,7 @@ static void bc26_init_thread_entry(void *parameter)
             result = -RT_ERROR;
             goto __exit;
         }
-        
+
         /* initialize successfully  */
         result = RT_EOK;
         break;
@@ -906,12 +903,12 @@ static int bc26_net_init(struct at_device *device)
 static int bc26_init(struct at_device *device)
 {
     struct at_device_bc26 *bc26 = RT_NULL;
-    
+
     RT_ASSERT(device);
-    
-    bc26 = (struct at_device_bc26 *) device->user_data;
-    bc26->power_status = RT_FALSE;//default power is off.
-    bc26->sleep_status = RT_FALSE;//default sleep is disabled.
+
+    bc26 = (struct at_device_bc26 *)device->user_data;
+    bc26->power_status = RT_FALSE; //default power is off.
+    bc26->sleep_status = RT_FALSE; //default sleep is disabled.
 
     /* initialize AT client */
     at_client_init(bc26->client_name, bc26->recv_line_num);
@@ -950,7 +947,7 @@ static int bc26_init(struct at_device *device)
 static int bc26_deinit(struct at_device *device)
 {
     RT_ASSERT(device);
-    
+
     return bc26_netdev_set_down(device->netdev);
 }
 
@@ -989,17 +986,17 @@ static int bc26_control(struct at_device *device, int cmd, void *arg)
 }
 
 const struct at_device_ops bc26_device_ops =
-{
-    bc26_init,
-    bc26_deinit,
-    bc26_control,
+    {
+        bc26_init,
+        bc26_deinit,
+        bc26_control,
 };
 
 static int bc26_device_class_register(void)
 {
     struct at_device_class *class = RT_NULL;
 
-    class = (struct at_device_class *) rt_calloc(1, sizeof(struct at_device_class));
+    class = (struct at_device_class *)rt_calloc(1, sizeof(struct at_device_class));
     if (class == RT_NULL)
     {
         LOG_E("no memory for device class create.");
@@ -1017,4 +1014,3 @@ static int bc26_device_class_register(void)
 INIT_DEVICE_EXPORT(bc26_device_class_register);
 
 #endif /* AT_DEVICE_USING_BC26 */
-


### PR DESCRIPTION
->air720
1.cat.1 compatible;
2.fix bugs
3.update at commands relay to the air720_at_manual 4.20

->bc26
1.fix bug (power key retain low , when the module comes into sleep mode,so the next time,when module wakes up ,the module can't come into sleep mode )