### PR TITLE
socket部分调整缓冲参数到menuconfig中进行配置

### DIFF
--- a/class/m5311/at_socket_m5311.c
+++ b/class/m5311/at_socket_m5311.c
@@ -64,12 +64,12 @@ static int str_to_hex(const char *source, char *dest, int max_dest_len)
 
         if(ch1 <= 9)
             *(dest + j) = ch1 + '0';
-		else
+        else
             *(dest + j) = ch1 + 'A' - 10;
 
         if(ch2 <= 9)
             *(dest + j + 1) = ch2 + '0';
-		else
+        else
             *(dest + j + 1) = ch2 + 'A' - 10;
 
         i++;
@@ -78,7 +78,7 @@ static int str_to_hex(const char *source, char *dest, int max_dest_len)
 
     *(dest + j) = '\0';
 
-	return j;
+    return j;
 }
 
 /**
@@ -177,12 +177,12 @@ static int m5311_socket_close(struct at_socket *socket)
     result = at_obj_exec_cmd(device->client, resp, "AT+IPCLOSE=%d", device_socket);
     if (result == 0)
     {
-    	LOG_I("%s device close socket(%d).", device->name, device_socket);
+        LOG_I("%s device close socket(%d).", device->name, device_socket);
     }
     else
     {
-    	LOG_E("%s device socket(%d) close failed, wait close OK timeout.", device->name, device_socket);
-	}
+        LOG_E("%s device socket(%d) close failed, wait close OK timeout.", device->name, device_socket);
+    }
 
     at_delete_resp(resp);
 
@@ -224,49 +224,49 @@ static int m5311_socket_connect(struct at_socket *socket, char *ip, int32_t port
     if (!is_client)
         return -RT_ERROR;
 
-	if (type == AT_SOCKET_UDP)
-	{
-		rt_strncpy(m5311_sock_info[device_socket].ip_addr, ip, 16);
-		m5311_sock_info[device_socket].port = port;
-	}
+    if (type == AT_SOCKET_UDP)
+    {
+        rt_strncpy(m5311_sock_info[device_socket].ip_addr, ip, 16);
+        m5311_sock_info[device_socket].port = port;
+    }
 
 __retry:
     /* clear socket connect event */
     event_result = SET_EVENT(device_socket, M5311_EVENT_CONN_OK | M5311_EVENT_CONN_FAIL);
     m5311_socket_event_recv(device, event_result, 0, RT_EVENT_FLAG_OR);
 
-	switch (type)
-	{
-	case AT_SOCKET_TCP:
-	/* send AT commands(eg: AT+IPSTART=0,"TCP","x.x.x.x", 1234) to connect TCP server */
-	/* AT+IPSTART=<sockid>,<type>,<addr>,<port>[,<cid>[,<domian>[,<protocol>]]] */
-		if (at_obj_exec_cmd(device->client, resp,
-				"AT+IPSTART=%d,\"TCP\",\"%s\",%d", device_socket, ip, port) < 0)
-		{
-			result = -RT_ERROR;
-			goto __exit;
-		}
-		resp = at_resp_set_info(resp, 128, 3, 10 * RT_TICK_PER_SECOND);
+    switch (type)
+    {
+    case AT_SOCKET_TCP:
+    /* send AT commands(eg: AT+IPSTART=0,"TCP","x.x.x.x", 1234) to connect TCP server */
+    /* AT+IPSTART=<sockid>,<type>,<addr>,<port>[,<cid>[,<domian>[,<protocol>]]] */
+        if (at_obj_exec_cmd(device->client, resp,
+                "AT+IPSTART=%d,\"TCP\",\"%s\",%d", device_socket, ip, port) < 0)
+        {
+            result = -RT_ERROR;
+            goto __exit;
+        }
+        resp = at_resp_set_info(resp, 128, 3, 10 * RT_TICK_PER_SECOND);
 
-	    if (at_resp_parse_line_args(resp, 3, "CONNECT OK") < 0)
-	    {
-	        result = -RT_ERROR;
-	    }
-		break;
+        if (at_resp_parse_line_args(resp, 3, "CONNECT OK") < 0)
+        {
+            result = -RT_ERROR;
+        }
+        break;
 
-	case AT_SOCKET_UDP:
-		if (at_obj_exec_cmd(device->client, resp,
-				"AT+IPSTART=%d,\"UDP\",\"%s\",%d", device_socket, ip, port) < 0)
-		{
-			result = -RT_ERROR;
-			goto __exit;
-		}
-		break;
+    case AT_SOCKET_UDP:
+        if (at_obj_exec_cmd(device->client, resp,
+                "AT+IPSTART=%d,\"UDP\",\"%s\",%d", device_socket, ip, port) < 0)
+        {
+            result = -RT_ERROR;
+            goto __exit;
+        }
+        break;
 
-	default:
-		LOG_E("%s device not supported connect type : %d.", device->name, type);
-		return -RT_ERROR;
-	}
+    default:
+        LOG_E("%s device not supported connect type : %d.", device->name, type);
+        return -RT_ERROR;
+    }
 
     if(!at_resp_get_line_by_kw(resp, "OK"))
     {
@@ -275,13 +275,13 @@ __retry:
 
     if (result != RT_EOK && retryed == RT_FALSE)
     {
-    	LOG_D("%s device socket(%d) connect failed, now retry.",
-    		  device->name, device_socket);
-    	if (m5311_socket_close(socket) < 0)
-    	{
-    		goto __exit;
-    	}
-    	retryed = RT_TRUE;
+        LOG_D("%s device socket(%d) connect failed, now retry.",
+              device->name, device_socket);
+        if (m5311_socket_close(socket) < 0)
+        {
+            goto __exit;
+        }
+        retryed = RT_TRUE;
         result = RT_EOK;
         goto __retry;
     }
@@ -349,18 +349,18 @@ static int m5311_socket_send(struct at_socket *socket, const char *buff,
             cur_pkt_size = M5311_MODULE_SEND_MAX_SIZE;
         }
 
-		char hex_data[bfsz * 2];
-		rt_memset(hex_data, 0, sizeof(hex_data));
-		str_to_hex(buff, hex_data, bfsz * 2);
+        char hex_data[bfsz * 2];
+        rt_memset(hex_data, 0, sizeof(hex_data));
+        str_to_hex(buff, hex_data, bfsz * 2);
 
         switch (type)
         {
         case AT_SOCKET_TCP:
             /* TCP : AT+IPSEND=<socket_id>,[<data_len>],<data>[,<pri_flag>] */
             if (at_obj_exec_cmd(device->client, resp, "AT+IPSEND=%d,%d,%s",
-            		            device_socket, (int)cur_pkt_size, hex_data) < 0)
+                                device_socket, (int)cur_pkt_size, hex_data) < 0)
             {
-            	LOG_D("%s", buff);
+                LOG_D("%s", buff);
                 result = -RT_ERROR;
                 goto __exit;
             }
@@ -546,7 +546,7 @@ static void urc_send_func(struct at_client *client, const char *data, rt_size_t 
     }
     else
     {
-    	m5311_socket_event_send(device, SET_EVENT(device_socket, M5311_EVENT_SEND_FAIL));
+        m5311_socket_event_send(device, SET_EVENT(device_socket, M5311_EVENT_SEND_FAIL));
     }
 }
 
@@ -570,9 +570,9 @@ static void urc_close_func(struct at_client *client, const char *data, rt_size_t
     socket = &(device->sockets[device_socket]);
 
     if (at_evt_cb_set[AT_SOCKET_EVT_CLOSED])
-	{
-		at_evt_cb_set[AT_SOCKET_EVT_CLOSED](socket, AT_SOCKET_EVT_CLOSED, RT_NULL, 0);
-	}
+    {
+        at_evt_cb_set[AT_SOCKET_EVT_CLOSED](socket, AT_SOCKET_EVT_CLOSED, RT_NULL, 0);
+    }
 }
 
 static void urc_recv_func(struct at_client *client, const char *data, rt_size_t size)

--- a/samples/at_sample_m5311.c
+++ b/samples/at_sample_m5311.c
@@ -28,8 +28,9 @@
 #include <at_log.h>
 
 /* Requirement:
- * AT_CMD_MAX_LEN     -> 2048
- * RT_SERIAL_RB_BUFSZ -> 4096
+ * AT_CMD_MAX_LEN              -> 2048
+ * RT_SERIAL_RB_BUFSZ          -> 4096
+ * M5311_SAMPLE_RECV_BUFF_LEN  -> 2048
  */
  
 #define M5311_SAMPLE_DEVICE_NAME    "m5311"


### PR DESCRIPTION
主要：socket部分调整缓冲参数到menuconfig中进行配置；  
增加对注册设备到系统所申请的接收缓冲说明。  
其他：删除不必要的注释代码以及单行语句括号。