### PR TITLE
Support alloc socket dynamically

### DIFF
--- a/class/a9g/at_socket_a9g.c
+++ b/class/a9g/at_socket_a9g.c
@@ -593,6 +593,7 @@ static const struct at_urc urc_table[] =
 
 static const struct at_socket_ops a9g_socket_ops = 
 {
+    RT_NULL,
     a9g_socket_connect,
     a9g_socket_close,
     a9g_socket_send,

--- a/class/a9g/at_socket_a9g.c
+++ b/class/a9g/at_socket_a9g.c
@@ -593,12 +593,14 @@ static const struct at_urc urc_table[] =
 
 static const struct at_socket_ops a9g_socket_ops = 
 {
-    RT_NULL,
     a9g_socket_connect,
     a9g_socket_close,
     a9g_socket_send,
     a9g_domain_resolve,
     a9g_socket_set_event_cb,
+#if defined(AT_SW_VERSION_NUM) && AT_SW_VERSION_NUM > 0x10300
+    RT_NULL,
+#endif
 };
 
 int a9g_socket_init(struct at_device *device)

--- a/class/air720/at_socket_air720.c
+++ b/class/air720/at_socket_air720.c
@@ -645,12 +645,13 @@ static const struct at_urc urc_table[] =
 };
 
 static const struct at_socket_ops air720_socket_ops =
-    {
-        air720_socket_connect,
-        air720_socket_close,
-        air720_socket_send,
-        air720_domain_resolve,
-        air720_socket_set_event_cb,
+{
+    RT_NULL,
+    air720_socket_connect,
+    air720_socket_close,
+    air720_socket_send,
+    air720_domain_resolve,
+    air720_socket_set_event_cb,
 };
 
 int air720_socket_init(struct at_device *device)

--- a/class/air720/at_socket_air720.c
+++ b/class/air720/at_socket_air720.c
@@ -646,12 +646,14 @@ static const struct at_urc urc_table[] =
 
 static const struct at_socket_ops air720_socket_ops =
 {
-    RT_NULL,
     air720_socket_connect,
     air720_socket_close,
     air720_socket_send,
     air720_domain_resolve,
     air720_socket_set_event_cb,
+#if defined(AT_SW_VERSION_NUM) && AT_SW_VERSION_NUM > 0x10300
+    RT_NULL,
+#endif
 };
 
 int air720_socket_init(struct at_device *device)

--- a/class/bc26/at_socket_bc26.c
+++ b/class/bc26/at_socket_bc26.c
@@ -759,6 +759,7 @@ static const struct at_urc urc_table[] =
 
 static const struct at_socket_ops bc26_socket_ops =
 {
+    RT_NULL,
     bc26_socket_connect,
     bc26_socket_close,
     bc26_socket_send,

--- a/class/bc26/at_socket_bc26.c
+++ b/class/bc26/at_socket_bc26.c
@@ -759,12 +759,14 @@ static const struct at_urc urc_table[] =
 
 static const struct at_socket_ops bc26_socket_ops =
 {
-    RT_NULL,
     bc26_socket_connect,
     bc26_socket_close,
     bc26_socket_send,
     bc26_domain_resolve,
     bc26_socket_set_event_cb,
+#if defined(AT_SW_VERSION_NUM) && AT_SW_VERSION_NUM > 0x10300
+    RT_NULL,
+#endif
 };
 
 int bc26_socket_init(struct at_device *device)

--- a/class/bc28/README.md
+++ b/class/bc28/README.md
@@ -1,0 +1,15 @@
+# BC28
+
+## 注意事项
+
+### 申请 socket
+
+- BC28 最多支持 7 个 socket，编号 0-6；
+- 如果 BC28 使用支持 MQTT 或 CoAP 协议的固件，则相关服务会占用部分 socket，因此最小可用的 socket 并不一定是 0；
+- 可以创建 1 个 UDP socket，多个 TCP socket；
+- 另外，执行 DNS 域名解析时也会占用 socket；
+
+### 连接 socket
+
+- R02 的基线版本固件才支持 `AT+QTCPIND` 查询 TCP 连接情况，因此目前采用保守的 30 秒延时来确保连接状态；
+

--- a/class/bc28/at_device_bc28.c
+++ b/class/bc28/at_device_bc28.c
@@ -24,8 +24,11 @@
 
 #include <stdio.h>
 #include <string.h>
-
 #include <at_device_bc28.h>
+
+#if !defined(AT_SW_VERSION_NUM) || AT_SW_VERSION_NUM < 0x10301
+#error "This AT Client version is older, please check and update latest AT Client!"
+#endif
 
 #define LOG_TAG                        "at.dev.bc28"
 #include <at_log.h>

--- a/class/bc28/at_socket_bc28.c
+++ b/class/bc28/at_socket_bc28.c
@@ -20,6 +20,7 @@
  * Change Logs:
  * Date           Author            Notes
  * 2020-02-13     luhuadong         first version
+ * 2020-07-19     luhuadong         support alloc socket
  */
 
 #include <stdio.h>
@@ -194,7 +195,7 @@ static int bc28_socket_close(struct at_socket *socket)
 {
     int result = RT_EOK;
     at_response_t resp = RT_NULL;
-    int device_socket = (int) socket->user_data + AT_DEVICE_BC28_MIN_SOCKET;
+    int device_socket = (int) socket->user_data;
     struct at_device *device = (struct at_device *) socket->device;
 
     resp = at_create_resp(64, 0, rt_tick_from_millisecond(3000));
@@ -223,16 +224,16 @@ static int bc28_socket_close(struct at_socket *socket)
  * create socket by AT commands.
  *
  * @param type connect socket type(tcp, udp)
- * @param port listen port (range: 0-65535), if 0 means get a random port
  *
  * @return >=0: create socket success, return the socket id (0-6)
  *          -1: send or exec AT commands error
  *          -5: no memory
  */
-static int bc28_socket_create(struct at_device *device, enum at_socket_type type, uint32_t port)
+static int bc28_socket_create(struct at_device *device, enum at_socket_type type)
 {
     const char *type_str = RT_NULL;
     uint32_t protocol = 0;
+    uint32_t port = 0; /* range: 0-65535, if 0 means get a random port */
     at_response_t resp = RT_NULL;
     int socket = -1, result = 0;
 
@@ -309,7 +310,7 @@ static int bc28_socket_connect(struct at_socket *socket, char *ip, int32_t port,
     uint32_t event = 0;
     at_response_t resp = RT_NULL;
     int result = 0, event_result = 0;
-    int device_socket = (int) socket->user_data + AT_DEVICE_BC28_MIN_SOCKET;
+    int device_socket = (int) socket->user_data;
     int return_socket = -1;
     struct at_device *device = (struct at_device *) socket->device;
 
@@ -326,32 +327,6 @@ static int bc28_socket_connect(struct at_socket *socket, char *ip, int32_t port,
     {
         LOG_E("no memory for resp create.");
         return -RT_ENOMEM;
-    }
-
-    return_socket = bc28_socket_create(device, type, 0);
-
-    if (return_socket != device_socket)
-    {
-        LOG_E("socket not match (request %d, return %d).", device_socket, return_socket);
-
-        result = at_obj_exec_cmd(device->client, resp, "AT+NSOCL=%d", return_socket);
-        if (result < 0)
-        {
-            LOG_E("%s device close socket(%d) failed [%d].", device->name, return_socket, result);
-        }
-        else
-        {
-            LOG_D("%s device close socket(%d).", device->name, return_socket);
-
-            /* notice the socket is disconnect by remote */
-            if (at_evt_cb_set[AT_SOCKET_EVT_CLOSED])
-            {
-                at_evt_cb_set[AT_SOCKET_EVT_CLOSED](socket, AT_SOCKET_EVT_CLOSED, NULL, 0);
-            }
-        }
-        
-        result = -RT_ERROR;
-        goto __exit;
     }
 
     /* if the protocol is not tcp, no need connect to server */
@@ -439,7 +414,7 @@ static int bc28_socket_send(struct at_socket *socket, const char *buff,
     int result = 0, event_result = 0;
     size_t cur_pkt_size = 0, sent_size = 0;
     at_response_t resp = RT_NULL;
-    int device_socket = (int) socket->user_data + AT_DEVICE_BC28_MIN_SOCKET;
+    int device_socket = (int) socket->user_data;
     struct at_device *device = (struct at_device *) socket->device;
     struct at_device_bc28 *bc28 = (struct at_device_bc28 *) device->user_data;
     rt_mutex_t lock = device->client->lock;
@@ -748,10 +723,10 @@ static void urc_close_func(struct at_client *client, const char *data, rt_size_t
 
     bc28_socket_event_send(device, SET_EVENT(device_socket, BC28_EVENT_CONN_FAIL));
     
-    if (device_socket - AT_DEVICE_BC28_MIN_SOCKET >= 0)
+    if (device_socket >= 0)
     {
         /* get at socket object by device socket descriptor */
-        socket = &(device->sockets[device_socket - AT_DEVICE_BC28_MIN_SOCKET]);
+        socket = &(device->sockets[device_socket]);
 
         /* notice the socket is disconnect by remote */
         if (at_evt_cb_set[AT_SOCKET_EVT_CLOSED])
@@ -828,7 +803,7 @@ static void urc_recv_func(struct at_client *client, const char *data, rt_size_t 
     rt_free(hex_buf);
 
     /* get at socket object by device socket descriptor */
-    socket = &(device->sockets[device_socket - AT_DEVICE_BC28_MIN_SOCKET]);
+    socket = &(device->sockets[device_socket]);
 
     /* notice the receive buffer and buffer size */
     if (at_evt_cb_set[AT_SOCKET_EVT_RECV])
@@ -895,6 +870,7 @@ static const struct at_urc urc_table[] =
 
 static const struct at_socket_ops bc28_socket_ops =
 {
+    bc28_socket_create,
     bc28_socket_connect,
     bc28_socket_close,
     bc28_socket_send,
@@ -916,7 +892,7 @@ int bc28_socket_class_register(struct at_device_class *class)
 {
     RT_ASSERT(class);
 
-    class->socket_num = AT_DEVICE_BC28_SOCKETS_NUM - AT_DEVICE_BC28_MIN_SOCKET;
+    class->socket_num = AT_DEVICE_BC28_SOCKETS_NUM;
     class->socket_ops = &bc28_socket_ops;
 
     return RT_EOK;

--- a/class/bc28/at_socket_bc28.c
+++ b/class/bc28/at_socket_bc28.c
@@ -25,8 +25,11 @@
 
 #include <stdio.h>
 #include <string.h>
-
 #include <at_device_bc28.h>
+
+#if !defined(AT_SW_VERSION_NUM) || AT_SW_VERSION_NUM < 0x10301
+#error "This AT Client version is older, please check and update latest AT Client!"
+#endif
 
 #define LOG_TAG                        "at.skt.bc28"
 #include <at_log.h>
@@ -870,12 +873,14 @@ static const struct at_urc urc_table[] =
 
 static const struct at_socket_ops bc28_socket_ops =
 {
-    bc28_socket_create,
     bc28_socket_connect,
     bc28_socket_close,
     bc28_socket_send,
     bc28_domain_resolve,
     bc28_socket_set_event_cb,
+#if defined(AT_SW_VERSION_NUM) && AT_SW_VERSION_NUM > 0x10300
+    bc28_socket_create,
+#endif
 };
 
 int bc28_socket_init(struct at_device *device)

--- a/class/ec20/at_socket_ec20.c
+++ b/class/ec20/at_socket_ec20.c
@@ -978,6 +978,7 @@ static const struct at_urc urc_table[] =
 
 static const struct at_socket_ops ec20_socket_ops =
 {
+    RT_NULL,
     ec20_socket_connect,
     ec20_socket_close,
     ec20_socket_send,

--- a/class/ec20/at_socket_ec20.c
+++ b/class/ec20/at_socket_ec20.c
@@ -978,12 +978,14 @@ static const struct at_urc urc_table[] =
 
 static const struct at_socket_ops ec20_socket_ops =
 {
-    RT_NULL,
     ec20_socket_connect,
     ec20_socket_close,
     ec20_socket_send,
     ec20_domain_resolve,
     ec20_socket_set_event_cb,
+#if defined(AT_SW_VERSION_NUM) && AT_SW_VERSION_NUM > 0x10300
+    RT_NULL,
+#endif
 };
 
 int ec20_socket_init(struct at_device *device)

--- a/class/ec200x/at_socket_ec200x.c
+++ b/class/ec200x/at_socket_ec200x.c
@@ -772,12 +772,14 @@ static const struct at_urc urc_table[] =
 
 static const struct at_socket_ops ec200x_socket_ops =
 {
-    RT_NULL,
     ec200x_socket_connect,
     ec200x_socket_close,
     ec200x_socket_send,
     ec200x_domain_resolve,
     ec200x_socket_set_event_cb,
+#if defined(AT_SW_VERSION_NUM) && AT_SW_VERSION_NUM > 0x10300
+    RT_NULL,
+#endif
 };
 
 int ec200x_socket_init(struct at_device *device)

--- a/class/ec200x/at_socket_ec200x.c
+++ b/class/ec200x/at_socket_ec200x.c
@@ -772,6 +772,7 @@ static const struct at_urc urc_table[] =
 
 static const struct at_socket_ops ec200x_socket_ops =
 {
+    RT_NULL,
     ec200x_socket_connect,
     ec200x_socket_close,
     ec200x_socket_send,

--- a/class/esp32/at_socket_esp32.c
+++ b/class/esp32/at_socket_esp32.c
@@ -388,12 +388,14 @@ static void esp32_socket_set_event_cb(at_socket_evt_t event, at_evt_cb_t cb)
 
 static const struct at_socket_ops esp32_socket_ops =
 {
-    RT_NULL,
     esp32_socket_connect,
     esp32_socket_close,
     esp32_socket_send,
     esp32_domain_resolve,
     esp32_socket_set_event_cb,
+#if defined(AT_SW_VERSION_NUM) && AT_SW_VERSION_NUM > 0x10300
+    RT_NULL,
+#endif
 };
 
 static void urc_send_func(struct at_client *client, const char *data, rt_size_t size)

--- a/class/esp32/at_socket_esp32.c
+++ b/class/esp32/at_socket_esp32.c
@@ -388,6 +388,7 @@ static void esp32_socket_set_event_cb(at_socket_evt_t event, at_evt_cb_t cb)
 
 static const struct at_socket_ops esp32_socket_ops =
 {
+    RT_NULL,
     esp32_socket_connect,
     esp32_socket_close,
     esp32_socket_send,

--- a/class/esp8266/at_socket_esp8266.c
+++ b/class/esp8266/at_socket_esp8266.c
@@ -388,6 +388,7 @@ static void esp8266_socket_set_event_cb(at_socket_evt_t event, at_evt_cb_t cb)
 
 static const struct at_socket_ops esp8266_socket_ops =
 {
+    RT_NULL,
     esp8266_socket_connect,
     esp8266_socket_close,
     esp8266_socket_send,

--- a/class/esp8266/at_socket_esp8266.c
+++ b/class/esp8266/at_socket_esp8266.c
@@ -388,12 +388,14 @@ static void esp8266_socket_set_event_cb(at_socket_evt_t event, at_evt_cb_t cb)
 
 static const struct at_socket_ops esp8266_socket_ops =
 {
-    RT_NULL,
     esp8266_socket_connect,
     esp8266_socket_close,
     esp8266_socket_send,
     esp8266_domain_resolve,
     esp8266_socket_set_event_cb,
+#if defined(AT_SW_VERSION_NUM) && AT_SW_VERSION_NUM > 0x10300
+    RT_NULL,
+#endif
 };
 
 static void urc_send_func(struct at_client *client, const char *data, rt_size_t size)

--- a/class/m26/at_socket_m26.c
+++ b/class/m26/at_socket_m26.c
@@ -654,6 +654,7 @@ static const struct at_urc urc_table[] =
 
 static const struct at_socket_ops m26_socket_ops =
 {
+    RT_NULL,
     m26_socket_connect,
     m26_socket_close,
     m26_socket_send,

--- a/class/m26/at_socket_m26.c
+++ b/class/m26/at_socket_m26.c
@@ -654,12 +654,14 @@ static const struct at_urc urc_table[] =
 
 static const struct at_socket_ops m26_socket_ops =
 {
-    RT_NULL,
     m26_socket_connect,
     m26_socket_close,
     m26_socket_send,
     m26_domain_resolve,
     m26_socket_set_event_cb,
+#if defined(AT_SW_VERSION_NUM) && AT_SW_VERSION_NUM > 0x10300
+    RT_NULL,
+#endif
 };
 
 int m26_socket_init(struct at_device *device)

--- a/class/m5311/at_socket_m5311.c
+++ b/class/m5311/at_socket_m5311.c
@@ -656,12 +656,14 @@ static const struct at_urc urc_table[] =
 
 static const struct at_socket_ops m5311_socket_ops =
 {
-    RT_NULL,
     m5311_socket_connect,
     m5311_socket_close,
     m5311_socket_send,
     m5311_domain_resolve,
     m5311_socket_set_event_cb,
+#if defined(AT_SW_VERSION_NUM) && AT_SW_VERSION_NUM > 0x10300
+    RT_NULL,
+#endif
 };
 
 int m5311_socket_init(struct at_device *device)

--- a/class/m5311/at_socket_m5311.c
+++ b/class/m5311/at_socket_m5311.c
@@ -656,6 +656,7 @@ static const struct at_urc urc_table[] =
 
 static const struct at_socket_ops m5311_socket_ops =
 {
+    RT_NULL,
     m5311_socket_connect,
     m5311_socket_close,
     m5311_socket_send,

--- a/class/m6315/at_socket_m6315.c
+++ b/class/m6315/at_socket_m6315.c
@@ -606,12 +606,14 @@ static const struct at_urc urc_table[] =
 
 static const struct at_socket_ops m6315_socket_ops =
 {
-    RT_NULL,
     m6315_socket_connect,
     m6315_socket_close,
     m6315_socket_send,
     m6315_domain_resolve,
     m6315_socket_set_event_cb,
+#if defined(AT_SW_VERSION_NUM) && AT_SW_VERSION_NUM > 0x10300
+    RT_NULL,
+#endif
 };
 
 int m6315_socket_init(struct at_device *device)

--- a/class/m6315/at_socket_m6315.c
+++ b/class/m6315/at_socket_m6315.c
@@ -606,6 +606,7 @@ static const struct at_urc urc_table[] =
 
 static const struct at_socket_ops m6315_socket_ops =
 {
+    RT_NULL,
     m6315_socket_connect,
     m6315_socket_close,
     m6315_socket_send,

--- a/class/me3616/at_socket_me3616.c
+++ b/class/me3616/at_socket_me3616.c
@@ -561,6 +561,7 @@ static const struct at_urc urc_table[] =
 
 static const struct at_socket_ops me3616_socket_ops =
 {
+    RT_NULL,
     me3616_socket_connect,
     me3616_socket_close,
     me3616_socket_send,

--- a/class/me3616/at_socket_me3616.c
+++ b/class/me3616/at_socket_me3616.c
@@ -561,12 +561,14 @@ static const struct at_urc urc_table[] =
 
 static const struct at_socket_ops me3616_socket_ops =
 {
-    RT_NULL,
     me3616_socket_connect,
     me3616_socket_close,
     me3616_socket_send,
     me3616_domain_resolve,
     me3616_socket_set_event_cb,
+#if defined(AT_SW_VERSION_NUM) && AT_SW_VERSION_NUM > 0x10300
+    RT_NULL,
+#endif
 };
 
 int me3616_socket_init(struct at_device *device)

--- a/class/mw31/at_socket_mw31.c
+++ b/class/mw31/at_socket_mw31.c
@@ -361,12 +361,14 @@ static void mw31_socket_set_event_cb(at_socket_evt_t event, at_evt_cb_t cb)
 
 static const struct at_socket_ops mw31_socket_ops =
 {
-    RT_NULL,
     mw31_socket_connect,
     mw31_socket_close,
     mw31_socket_send,
     mw31_domain_resolve,
     mw31_socket_set_event_cb,
+#if defined(AT_SW_VERSION_NUM) && AT_SW_VERSION_NUM > 0x10300
+    RT_NULL,
+#endif
 };
 
 static void urc_recv_func(struct at_client *client, const char *data, rt_size_t size)

--- a/class/mw31/at_socket_mw31.c
+++ b/class/mw31/at_socket_mw31.c
@@ -361,6 +361,7 @@ static void mw31_socket_set_event_cb(at_socket_evt_t event, at_evt_cb_t cb)
 
 static const struct at_socket_ops mw31_socket_ops =
 {
+    RT_NULL,
     mw31_socket_connect,
     mw31_socket_close,
     mw31_socket_send,

--- a/class/n21/at_socket_n21.c
+++ b/class/n21/at_socket_n21.c
@@ -630,12 +630,13 @@ static const struct at_urc urc_table[] =
 };
 
 static const struct at_socket_ops n21_socket_ops =
-    {
-        n21_socket_connect,
-        n21_socket_close,
-        n21_socket_send,
-        n21_domain_resolve,
-        n21_socket_set_event_cb,
+{
+    RT_NULL,
+    n21_socket_connect,
+    n21_socket_close,
+    n21_socket_send,
+    n21_domain_resolve,
+    n21_socket_set_event_cb,
 };
 
 int n21_socket_init(struct at_device *device)

--- a/class/n21/at_socket_n21.c
+++ b/class/n21/at_socket_n21.c
@@ -617,26 +617,27 @@ static void urc_recv_func(struct at_client *client, const char *data, rt_size_t 
 
 /* n21 device URC table for the socket data */
 static const struct at_urc urc_table[] =
-    {
-        {"+TCPSETUP:", "\r\n", urc_connect_func},
-        {"+UDPSETUP:", "\r\n", urc_connect_func},
-        {"+TCPSEND:", "\r\n", urc_send_func},
-        {"+UDPSEND:", "\r\n", urc_send_func},
-        {"+TCPCLOSE:", "\r\n", urc_close_func},
-        {"+UDPCLOSE:", "\r\n", urc_close_func},
-        {"+TCPRECV:", "\r\n", urc_recv_func},
-        {"+UDPRECV:", "\r\n", urc_recv_func},
-
+{
+    {"+TCPSETUP:", "\r\n", urc_connect_func},
+    {"+UDPSETUP:", "\r\n", urc_connect_func},
+    {"+TCPSEND:", "\r\n", urc_send_func},
+    {"+UDPSEND:", "\r\n", urc_send_func},
+    {"+TCPCLOSE:", "\r\n", urc_close_func},
+    {"+UDPCLOSE:", "\r\n", urc_close_func},
+    {"+TCPRECV:", "\r\n", urc_recv_func},
+    {"+UDPRECV:", "\r\n", urc_recv_func},
 };
 
 static const struct at_socket_ops n21_socket_ops =
 {
-    RT_NULL,
     n21_socket_connect,
     n21_socket_close,
     n21_socket_send,
     n21_domain_resolve,
     n21_socket_set_event_cb,
+#if defined(AT_SW_VERSION_NUM) && AT_SW_VERSION_NUM > 0x10300
+    RT_NULL,
+#endif
 };
 
 int n21_socket_init(struct at_device *device)

--- a/class/n58/at_socket_n58.c
+++ b/class/n58/at_socket_n58.c
@@ -624,27 +624,27 @@ static void urc_recv_func(struct at_client *client, const char *data, rt_size_t 
 
 /* n58 device URC table for the socket data */
 static const struct at_urc urc_table[] =
-    {
-
-        {"+TCPSETUP:", "\r\n", urc_connect_func},
-        {"+UDPSETUP:", "\r\n", urc_connect_func},
-        {"+TCPSEND:", "\r\n", urc_send_func},
-        {"+UDPSEND:", "\r\n", urc_send_func},
-        {"+TCPCLOSE:", "\r\n", urc_close_func},
-        {"+UDPCLOSE:", "\r\n", urc_close_func},
-        {"+TCPRECV:", "\r\n", urc_recv_func},
-        {"+UDPRECV:", "\r\n", urc_recv_func},
-
+{
+    {"+TCPSETUP:", "\r\n", urc_connect_func},
+    {"+UDPSETUP:", "\r\n", urc_connect_func},
+    {"+TCPSEND:", "\r\n", urc_send_func},
+    {"+UDPSEND:", "\r\n", urc_send_func},
+    {"+TCPCLOSE:", "\r\n", urc_close_func},
+    {"+UDPCLOSE:", "\r\n", urc_close_func},
+    {"+TCPRECV:", "\r\n", urc_recv_func},
+    {"+UDPRECV:", "\r\n", urc_recv_func},
 };
 
 static const struct at_socket_ops n58_socket_ops =
 {
-    RT_NULL,
     n58_socket_connect,
     n58_socket_close,
     n58_socket_send,
     n58_domain_resolve,
     n58_socket_set_event_cb,
+#if defined(AT_SW_VERSION_NUM) && AT_SW_VERSION_NUM > 0x10300
+    RT_NULL,
+#endif
 };
 
 int n58_socket_init(struct at_device *device)

--- a/class/n58/at_socket_n58.c
+++ b/class/n58/at_socket_n58.c
@@ -638,12 +638,13 @@ static const struct at_urc urc_table[] =
 };
 
 static const struct at_socket_ops n58_socket_ops =
-    {
-        n58_socket_connect,
-        n58_socket_close,
-        n58_socket_send,
-        n58_domain_resolve,
-        n58_socket_set_event_cb,
+{
+    RT_NULL,
+    n58_socket_connect,
+    n58_socket_close,
+    n58_socket_send,
+    n58_domain_resolve,
+    n58_socket_set_event_cb,
 };
 
 int n58_socket_init(struct at_device *device)

--- a/class/rw007/at_socket_rw007.c
+++ b/class/rw007/at_socket_rw007.c
@@ -387,6 +387,7 @@ static void rw007_socket_set_event_cb(at_socket_evt_t event, at_evt_cb_t cb)
 
 static const struct at_socket_ops rw007_socket_ops =
 {
+    RT_NULL,
     rw007_socket_connect,
     rw007_socket_close,
     rw007_socket_send,

--- a/class/rw007/at_socket_rw007.c
+++ b/class/rw007/at_socket_rw007.c
@@ -387,12 +387,14 @@ static void rw007_socket_set_event_cb(at_socket_evt_t event, at_evt_cb_t cb)
 
 static const struct at_socket_ops rw007_socket_ops =
 {
-    RT_NULL,
     rw007_socket_connect,
     rw007_socket_close,
     rw007_socket_send,
     rw007_domain_resolve,
     rw007_socket_set_event_cb,
+#if defined(AT_SW_VERSION_NUM) && AT_SW_VERSION_NUM > 0x10300
+    RT_NULL,
+#endif
 };
 
 static void urc_send_func(struct at_client *client, const char *data, rt_size_t size)

--- a/class/sim76xx/at_socket_sim76xx.c
+++ b/class/sim76xx/at_socket_sim76xx.c
@@ -671,12 +671,14 @@ static struct at_urc urc_table[] =
 
 static const struct at_socket_ops sim76xx_socket_ops =
 {
-    RT_NULL,
     sim76xx_socket_connect,
     sim76xx_socket_close,
     sim76xx_socket_send,
     sim76xx_domain_resolve,
     sim76xx_socket_set_event_cb,
+#if defined(AT_SW_VERSION_NUM) && AT_SW_VERSION_NUM > 0x10300
+    RT_NULL,
+#endif
 };
 
 /* initialize sim76xx device network URC feature */

--- a/class/sim76xx/at_socket_sim76xx.c
+++ b/class/sim76xx/at_socket_sim76xx.c
@@ -671,6 +671,7 @@ static struct at_urc urc_table[] =
 
 static const struct at_socket_ops sim76xx_socket_ops =
 {
+    RT_NULL,
     sim76xx_socket_connect,
     sim76xx_socket_close,
     sim76xx_socket_send,

--- a/class/sim800c/at_socket_sim800c.c
+++ b/class/sim800c/at_socket_sim800c.c
@@ -611,6 +611,7 @@ static const struct at_urc urc_table[] =
 
 static const struct at_socket_ops sim800c_socket_ops =
 {
+    RT_NULL,
     sim800c_socket_connect,
     sim800c_socket_close,
     sim800c_socket_send,

--- a/class/sim800c/at_socket_sim800c.c
+++ b/class/sim800c/at_socket_sim800c.c
@@ -611,12 +611,14 @@ static const struct at_urc urc_table[] =
 
 static const struct at_socket_ops sim800c_socket_ops =
 {
-    RT_NULL,
     sim800c_socket_connect,
     sim800c_socket_close,
     sim800c_socket_send,
     sim800c_domain_resolve,
     sim800c_socket_set_event_cb,
+#if defined(AT_SW_VERSION_NUM) && AT_SW_VERSION_NUM > 0x10300
+    RT_NULL,
+#endif
 };
 
 int sim800c_socket_init(struct at_device *device)

--- a/class/w60x/at_socket_w60x.c
+++ b/class/w60x/at_socket_w60x.c
@@ -351,12 +351,14 @@ static void w60x_socket_set_event_cb(at_socket_evt_t event, at_evt_cb_t cb)
 
 static const struct at_socket_ops w60x_socket_ops =
 {
-    RT_NULL,
     w60x_socket_connect,
     w60x_socket_close,
     w60x_socket_send,
     w60x_domain_resolve,
     w60x_socket_set_event_cb,
+#if defined(AT_SW_VERSION_NUM) && AT_SW_VERSION_NUM > 0x10300
+    RT_NULL,
+#endif
 };
 
 static void urc_recv_func(struct at_client *client, const char *data, rt_size_t size)

--- a/class/w60x/at_socket_w60x.c
+++ b/class/w60x/at_socket_w60x.c
@@ -351,6 +351,7 @@ static void w60x_socket_set_event_cb(at_socket_evt_t event, at_evt_cb_t cb)
 
 static const struct at_socket_ops w60x_socket_ops =
 {
+    RT_NULL,
     w60x_socket_connect,
     w60x_socket_close,
     w60x_socket_send,


### PR DESCRIPTION
由于部分 AT 模块/固件（比如 BC28）在申请 socket 时并不一定从 0 开始，运行过程的其他服务也可能会占用 socket（比如 DNS 域名解析），因此造成申请的 socket 并不连续。这种情况与 at socket 框架的实现存在冲突，对 at device 的实现造成较大限制。

因此我提出了一种修改方案 [#3755](https://github.com/RT-Thread/rt-thread/pull/3755)，在 at_socket_ops 结构体增加一个成员函数 at_socket，用于申请并返回 AT 设备真实可用的 socket 号，at device 模块可以根据自身情况决定是否需要实现该函数。

同时，为了兼容本次修改，我在 at_device 其他所有设备的 at_socket_ops 构造中均添加了 at_socket 指向 RT_NULL。所以不会影响其他模块的使用。

```c
static const struct at_socket_ops rw007_socket_ops =
{
    RT_NULL,
    rw007_socket_connect,
    rw007_socket_close,
    rw007_socket_send,
    rw007_domain_resolve,
    rw007_socket_set_event_cb,
};

```