### PR TITLE
fix: at_device_air720.c 编译错误

### DIFF
--- a/class/air720/at_device_air720.c
+++ b/class/air720/at_device_air720.c
@@ -221,7 +221,7 @@ __exit:
     return result;
 }
 
-int air720_reboot(struct at_device *device);
+static int air720_reboot(struct at_device *device);
 
 static void check_link_status_entry(void *parameter)
 {
@@ -926,7 +926,7 @@ static int air720_deinit(struct at_device *device)
     return air720_netdev_set_down(device->netdev);
 }
 
-int air720_reboot(struct at_device *device)
+static int air720_reboot(struct at_device *device)
 {
     air720_power_off(device);
     rt_thread_mdelay(2000);

--- a/class/air720/at_device_air720.c
+++ b/class/air720/at_device_air720.c
@@ -926,7 +926,7 @@ static int air720_deinit(struct at_device *device)
     return air720_netdev_set_down(device->netdev);
 }
 
-static int air720_reboot(struct at_device *device)
+int air720_reboot(struct at_device *device)
 {
     air720_power_off(device);
     rt_thread_mdelay(2000);
@@ -985,9 +985,9 @@ static int air720_control(struct at_device *device, int cmd, void *arg)
     case AT_DEVICE_CTRL_RESET:
         result = air720_reset(device);
         break;
-    case AT_DEVICE_CTRL_REBOOT:
-        result = air720_reboot(device);
-        break;
+    //case AT_DEVICE_CTRL_REBOOT:
+    //    result = air720_reboot(device);
+    //    break;
     default:
         LOG_E("input error control command(%d).", cmd);
         break;


### PR DESCRIPTION
1. AT_DEVICE_CTRL_REBOOT 已经被移除? 注释掉吧
2. air720_reboot声明有误, 一个声明为static,一个不是, 修正之