### PR TITLE
Bug(air720): air720_socket send return value may cause send error.

### DIFF
--- a/class/air720/at_socket_air720.c
+++ b/class/air720/at_socket_air720.c
@@ -334,7 +334,7 @@ __exit:
         at_delete_resp(resp);
     }
 
-    return result;
+    return result > 0 ? sent_size : result;
 }
 
 /**


### PR DESCRIPTION
if split a file to multi package (every package is 4K), then the return value cause sended length calculate error.