### PR TITLE
add at device probe

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -4,6 +4,13 @@ cwd = GetCurrentDir()
 path = [cwd + '/inc']
 src  = Glob('src/*.c')
 
+# PROBE
+if GetDepend(['AT_DEVICE_USING_PROBE']):
+    path += [cwd + '/class/probe']
+    src += Glob('class/probe/at_device_probe.c')
+    if GetDepend(['AT_DEVICE_PROBE_SAMPLE']):
+        src += Glob('samples/at_sample_probe.c')
+
 # A9G
 if GetDepend(['AT_DEVICE_USING_A9G']):
     path += [cwd + '/class/a9g']

--- a/class/a9g/at_device_a9g.c
+++ b/class/a9g/at_device_a9g.c
@@ -107,7 +107,7 @@ static int a9g_netdev_set_info(struct netdev *netdev)
     ip_addr_t addr;
     at_response_t resp = RT_NULL;
     struct at_device *device = RT_NULL;
-	
+    
     RT_ASSERT(netdev);
 
     device = at_device_get_by_name(AT_DEVICE_NAMETYPE_NETDEV, netdev->name);
@@ -175,7 +175,7 @@ static int a9g_netdev_set_info(struct netdev *netdev)
         char ipaddr[IP_ADDR_SIZE_MAX] = {0};
 
         at_resp_set_info(resp, A9G_IPADDR_RESP_SIZE, 2, A9G_INFO_RESP_TIMO);
-		
+        
         /* send "AT+CIFSR" commond to get IP address */
         if (at_obj_exec_cmd(device->client, resp, "AT+CIFSR") < 0)
         {
@@ -429,7 +429,7 @@ static int a9g_ping_domain_resolve(struct at_device *device, const char *name, c
         result = -RT_ERROR;
         goto __exit;
     }
-	
+    
     if (at_resp_parse_line_args_by_kw(resp, "+CDNSGIP:", "%*[^,],%*[^,],\"%[^\"]", recv_ip) < 0)
     {
         rt_thread_mdelay(100);
@@ -602,15 +602,15 @@ static void a9g_init_thread_entry(void *parameter)
             result = -RT_ERROR;
             goto __exit;
         }
-		
-		/* make the device restart */
+        
+        /* make the device restart */
         AT_SEND_CMD(client, resp, 0, 300, "AT+RST=1");
         for(i = 0; i<=30; i++)
         {
             i++;
             rt_thread_mdelay(1000);
         }
-		
+        
         /* waiting for dirty data to be digested */
         rt_thread_mdelay(1000);
 
@@ -658,14 +658,14 @@ static void a9g_init_thread_entry(void *parameter)
                 }
                 rt_thread_mdelay(1000);
             }
-			
+            
             AT_SEND_CMD(client, resp, 0, 1000, "AT+CGDCONT=1,\"IP\",\"CMNET\"");
             rt_thread_mdelay(10);
             AT_SEND_CMD(client, resp, 0, 5 * 1000, "AT+CGACT=1,1");
             rt_thread_mdelay(10);
             at_resp_parse_line_args_by_kw(resp, "OK", "%s", &parsed_data);
             
-			if (!strncmp(parsed_data, "OK", sizeof(parsed_data)))
+            if (!strncmp(parsed_data, "OK", sizeof(parsed_data)))
             {
                 LOG_D("a9g device(%s) GPRS network is registered(%s).", device->name, parsed_data);
                 break;
@@ -736,7 +736,7 @@ static void a9g_init_thread_entry(void *parameter)
             result = -RT_ERROR;
             goto __exit;
         }
-#ifdef	AT_USING_A9G_GPS
+#ifdef  AT_USING_A9G_GPS
         AT_SEND_CMD(client, resp, 0, 300, "AT+GPS?");
         at_resp_parse_line_args_by_kw(resp, "+GPS:", "+GPS: %d", &qimux);
         if (qimux == 0)
@@ -827,14 +827,18 @@ static int a9g_init(struct at_device *device)
 {
     struct at_device_a9g *a9g = (struct at_device_a9g *) device->user_data;
 
-    /* initialize AT client */
-    at_client_init(a9g->client_name, a9g->recv_line_num);
-
     device->client = at_client_get(a9g->client_name);
     if (device->client == RT_NULL)
     {
-        LOG_E("a9g device(%s) initialize failed, get AT client(%s) failed.", a9g->device_name, a9g->client_name);
-        return -RT_ERROR;
+        /* initialize AT client */
+        at_client_init(a9g->client_name, a9g->recv_line_num);
+
+        device->client = at_client_get(a9g->client_name);
+        if (device->client == RT_NULL)
+        {
+            LOG_E("a9g device(%s) initialize failed, get AT client(%s) failed.", a9g->device_name, a9g->client_name);
+            return -RT_ERROR;
+        }
     }
 
     /* register URC data execution function  */
@@ -851,8 +855,8 @@ static int a9g_init(struct at_device *device)
         LOG_E("a9g device(%s) initialize failed, get network interface device failed.", a9g->device_name);
         return -RT_ERROR;
     }
-	
-	/* initialize a9g pin configuration */
+    
+    /* initialize a9g pin configuration */
     if (a9g->power_pin != -1 && a9g->power_status_pin != -1)
     {
         rt_pin_mode(a9g->power_pin, PIN_MODE_OUTPUT);

--- a/class/air720/at_device_air720.c
+++ b/class/air720/at_device_air720.c
@@ -885,14 +885,18 @@ static int air720_init(struct at_device *device)
 {
     struct at_device_air720 *air720 = (struct at_device_air720 *)device->user_data;
 
-    /* initialize AT client */
-    at_client_init(air720->client_name, air720->recv_line_num);
-
     device->client = at_client_get(air720->client_name);
     if (device->client == RT_NULL)
     {
-        LOG_E("air720 device(%s) initialize failed, get AT client(%s) failed.", air720->device_name, air720->client_name);
-        return -RT_ERROR;
+        /* initialize AT client */
+        at_client_init(air720->client_name, air720->recv_line_num);
+
+        device->client = at_client_get(air720->client_name);
+        if (device->client == RT_NULL)
+        {
+            LOG_E("air720 device(%s) initialize failed, get AT client(%s) failed.", air720->device_name, air720->client_name);
+            return -RT_ERROR;
+        }
     }
 
     /* register URC data execution function  */
@@ -1019,6 +1023,17 @@ static int air720_device_class_register(void)
     air720_socket_class_register(class);
 #endif
     class->device_ops = &air720_device_ops;
+
+#ifdef AT_DEVICE_USING_PROBE
+    {
+        /* AirM2M_Air724UG_V907_LTE_AT */
+        static struct at_device_probe_kw air720_kw = {"AirM2M_", "AirM2M_%[^_]"};
+    
+        class->compatible[0] = "Air720";
+        class->compatible[1] = "Air724UG";
+        at_device_class_probe_kw_ati_register(&air720_kw);
+    }
+#endif /* __AT_DEVICE_PROBE_H__ */
 
     return at_device_class_register(class, AT_DEVICE_CLASS_AIR720);
 }

--- a/class/bc26/at_device_bc26.c
+++ b/class/bc26/at_device_bc26.c
@@ -910,14 +910,18 @@ static int bc26_init(struct at_device *device)
     bc26->power_status = RT_FALSE; //default power is off.
     bc26->sleep_status = RT_FALSE; //default sleep is disabled.
 
-    /* initialize AT client */
-    at_client_init(bc26->client_name, bc26->recv_line_num);
-
     device->client = at_client_get(bc26->client_name);
     if (device->client == RT_NULL)
     {
-        LOG_E("get AT client(%s) failed.", bc26->client_name);
-        return -RT_ERROR;
+        /* initialize AT client */
+        at_client_init(bc26->client_name, bc26->recv_line_num);
+
+        device->client = at_client_get(bc26->client_name);
+        if (device->client == RT_NULL)
+        {
+            LOG_E("get AT client(%s) failed.", bc26->client_name);
+            return -RT_ERROR;
+        }
     }
 
     /* register URC data execution function  */

--- a/class/bc28/at_device_bc28.c
+++ b/class/bc28/at_device_bc28.c
@@ -872,14 +872,18 @@ static int bc28_init(struct at_device *device)
     rt_device_control(serial, RT_DEVICE_CTRL_CONFIG, &config);
     rt_device_close(serial);
 
-    /* initialize AT client */
-    at_client_init(bc28->client_name, bc28->recv_bufsz);
-
     device->client = at_client_get(bc28->client_name);
     if (device->client == RT_NULL)
     {
-        LOG_E("get AT client(%s) failed.", bc28->client_name);
-        return -RT_ERROR;
+        /* initialize AT client */
+        at_client_init(bc28->client_name, bc28->recv_bufsz);
+
+        device->client = at_client_get(bc28->client_name);
+        if (device->client == RT_NULL)
+        {
+            LOG_E("get AT client(%s) failed.", bc28->client_name);
+            return -RT_ERROR;
+        }
     }
 
     /* register URC data execution function  */

--- a/class/ec20/at_device_ec20.c
+++ b/class/ec20/at_device_ec20.c
@@ -938,14 +938,18 @@ static int ec20_init(struct at_device *device)
 {
     struct at_device_ec20 *ec20 = (struct at_device_ec20 *) device->user_data;
 
-    /* initialize AT client */
-    at_client_init(ec20->client_name, ec20->recv_line_num);
-
     device->client = at_client_get(ec20->client_name);
     if (device->client == RT_NULL)
     {
-        LOG_E("get AT client(%s) failed.", ec20->client_name);
-        return -RT_ERROR;
+        /* initialize AT client */
+        at_client_init(ec20->client_name, ec20->recv_line_num);
+
+        device->client = at_client_get(ec20->client_name);
+        if (device->client == RT_NULL)
+        {
+            LOG_E("get AT client(%s) failed.", ec20->client_name);
+            return -RT_ERROR;
+        }
     }
 
     /* register URC data execution function  */

--- a/class/ec200x/at_device_ec200x.c
+++ b/class/ec200x/at_device_ec200x.c
@@ -902,14 +902,18 @@ static int ec200x_init(struct at_device *device)
     ec200x->power_status = RT_FALSE;//default power is off.
     ec200x->sleep_status = RT_FALSE;//default sleep is disabled.
 
-    /* initialize AT client */
-    at_client_init(ec200x->client_name, ec200x->recv_line_num);
-
     device->client = at_client_get(ec200x->client_name);
     if (device->client == RT_NULL)
     {
-        LOG_E("get AT client(%s) failed.", ec200x->client_name);
-        return -RT_ERROR;
+        /* initialize AT client */
+        at_client_init(ec200x->client_name, ec200x->recv_line_num);
+
+        device->client = at_client_get(ec200x->client_name);
+        if (device->client == RT_NULL)
+        {
+            LOG_E("get AT client(%s) failed.", ec200x->client_name);
+            return -RT_ERROR;
+        }
     }
 
     /* register URC data execution function  */
@@ -1009,6 +1013,17 @@ static int ec200x_device_class_register(void)
     ec200x_socket_class_register(class);
 #endif
     class->device_ops = &ec200x_device_ops;
+
+#ifdef AT_DEVICE_USING_PROBE
+    {
+        /* Revision: EC200TCNDAR02A09M16 */
+        static struct at_device_probe_kw ec200x_kw = {"Revision: ", "Revision: %s"};
+    
+        class->compatible[0] = "EC200T";
+        class->compatible[1] = "EC20";
+        at_device_class_probe_kw_ati_register(&ec200x_kw);
+    }
+#endif /* __AT_DEVICE_PROBE_H__ */
 
     return at_device_class_register(class, AT_DEVICE_CLASS_EC200X);
 }

--- a/class/esp32/at_device_esp32.c
+++ b/class/esp32/at_device_esp32.c
@@ -318,7 +318,7 @@ static int esp32_netdev_set_dns_server(struct netdev *netdev, uint8_t dns_num, i
         return -RT_ENOMEM;
     }
 
-    /* send dns server set commond "AT+CIPDNS_CUR=<enable>[,<DNS	server0>,<DNS	server1>]" and wait response */
+    /* send dns server set commond "AT+CIPDNS_CUR=<enable>[,<DNS    server0>,<DNS   server1>]" and wait response */
     if (at_obj_exec_cmd(device->client, resp, "AT+CIPDNS_CUR=1,\"%s\"", inet_ntoa(*dns_server)) < 0)
     {
         LOG_E("%s device set DNS failed.", device->name);
@@ -789,14 +789,17 @@ static int esp32_init(struct at_device *device)
 {
     struct at_device_esp32 *esp32 = (struct at_device_esp32 *) device->user_data;
 
-    /* initialize AT client */
-    at_client_init(esp32->client_name, esp32->recv_line_num);
-
-    device->client = at_client_get(esp32->client_name);
     if (device->client == RT_NULL)
     {
-        LOG_E("get AT client(%s) failed.", esp32->client_name);
-        return -RT_ERROR;
+        /* initialize AT client */
+        at_client_init(esp32->client_name, esp32->recv_line_num);
+
+        device->client = at_client_get(esp32->client_name);
+        if (device->client == RT_NULL)
+        {
+            LOG_E("get AT client(%s) failed.", esp32->client_name);
+            return -RT_ERROR;
+        }
     }
 
     /* register URC data execution function  */

--- a/class/m26/at_device_m26.c
+++ b/class/m26/at_device_m26.c
@@ -768,14 +768,18 @@ static int m26_init(struct at_device *device)
 {
     struct at_device_m26 *m26 = (struct at_device_m26 *) device->user_data;
 
-    /* initialize AT client */
-    at_client_init(m26->client_name, m26->recv_line_num);
-
     device->client = at_client_get(m26->client_name);
     if (device->client == RT_NULL)
     {
-        LOG_E("get AT client(%s) failed.", m26->client_name);
-        return -RT_ERROR;
+        /* initialize AT client */
+        at_client_init(m26->client_name, m26->recv_line_num);
+
+        device->client = at_client_get(m26->client_name);
+        if (device->client == RT_NULL)
+        {
+            LOG_E("get AT client(%s) failed.", m26->client_name);
+            return -RT_ERROR;
+        }
     }
 
     /* register URC data execution function  */

--- a/class/m5311/at_device_m5311.c
+++ b/class/m5311/at_device_m5311.c
@@ -722,14 +722,18 @@ static int m5311_init(struct at_device *device)
 {
     struct at_device_m5311 *m5311 = (struct at_device_m5311 *) device->user_data;
 
-    /* initialize AT client */
-    at_client_init(m5311->client_name, m5311->recieve_line_num);
-
     device->client = at_client_get(m5311->client_name);
     if (device->client == RT_NULL)
     {
-        LOG_E("get AT client(%s) failed.", m5311->client_name);
-        return -RT_ERROR;
+        /* initialize AT client */
+        at_client_init(m5311->client_name, m5311->recieve_line_num);
+
+        device->client = at_client_get(m5311->client_name);
+        if (device->client == RT_NULL)
+        {
+            LOG_E("get AT client(%s) failed.", m5311->client_name);
+            return -RT_ERROR;
+        }
     }
 
 #ifdef AT_USING_SOCKET

--- a/class/m6315/at_device_m6315.c
+++ b/class/m6315/at_device_m6315.c
@@ -413,7 +413,7 @@ static int m6315_netdev_ping(struct netdev *netdev, const char *host,
     at_response_t resp = RT_NULL;
     struct at_device *device = RT_NULL;
     int sent, recv, lost, min, max, avg;
-		
+        
     RT_ASSERT(netdev);
     RT_ASSERT(host);
     RT_ASSERT(ping_resp);
@@ -588,7 +588,7 @@ static void m6315_init_thread_entry(void *parameter)
             result = -RT_ETIMEOUT;
             goto __exit;
         }
-								
+                                
         /* disable echo */
         AT_SEND_CMD(client, resp, 0, 300, "ATE0");
         /* get module version */
@@ -873,14 +873,18 @@ static int m6315_init(struct at_device *device)
 {
     struct at_device_m6315 *m6315 = (struct at_device_m6315 *) device->user_data;
 
-    /* initialize AT client */
-    at_client_init(m6315->client_name, m6315->recv_line_num);
-
     device->client = at_client_get(m6315->client_name);
     if (device->client == RT_NULL)
     {
-        LOG_E("get AT client(%s) failed.", m6315->client_name);
-        return -RT_ERROR;
+        /* initialize AT client */
+        at_client_init(m6315->client_name, m6315->recv_line_num);
+
+        device->client = at_client_get(m6315->client_name);
+        if (device->client == RT_NULL)
+        {
+            LOG_E("get AT client(%s) failed.", m6315->client_name);
+            return -RT_ERROR;
+        }
     }
 
     /* register URC data execution function  */

--- a/class/me3616/at_device_me3616.c
+++ b/class/me3616/at_device_me3616.c
@@ -840,14 +840,18 @@ static int me3616_init(struct at_device *device)
     me3616->power_status = RT_FALSE;//default power is off.
     me3616->sleep_status = RT_FALSE;//default sleep is disabled.
 
-    /* initialize AT client */
-    at_client_init(me3616->client_name, me3616->recv_line_num);
-
     device->client = at_client_get(me3616->client_name);
     if (device->client == RT_NULL)
     {
-        LOG_E("get AT client(%s) failed.", me3616->client_name);
-        return -RT_ERROR;
+        /* initialize AT client */
+        at_client_init(me3616->client_name, me3616->recv_line_num);
+
+        device->client = at_client_get(me3616->client_name);
+        if (device->client == RT_NULL)
+        {
+            LOG_E("get AT client(%s) failed.", me3616->client_name);
+            return -RT_ERROR;
+        }
     }
 
     /* register URC data execution function  */

--- a/class/mw31/at_device_mw31.c
+++ b/class/mw31/at_device_mw31.c
@@ -595,14 +595,18 @@ static int mw31_init(struct at_device *device)
 {
     struct at_device_mw31 *mw31 = (struct at_device_mw31 *) device->user_data;
 
-    /* initialize AT client */
-    at_client_init(mw31->client_name, mw31->recv_line_num);
-
     device->client = at_client_get(mw31->client_name);
     if (device->client == RT_NULL)
     {
-        LOG_E("get AT client(%s) failed.", mw31->client_name);
-        return -RT_ERROR;
+        /* initialize AT client */
+        at_client_init(mw31->client_name, mw31->recv_line_num);
+
+        device->client = at_client_get(mw31->client_name);
+        if (device->client == RT_NULL)
+        {
+            LOG_E("get AT client(%s) failed.", mw31->client_name);
+            return -RT_ERROR;
+        }
     }
 
     /* register URC data execution function  */

--- a/class/n21/at_device_n21.c
+++ b/class/n21/at_device_n21.c
@@ -784,14 +784,18 @@ static int n21_init(struct at_device *device)
 {
     struct at_device_n21 *n21 = (struct at_device_n21 *)device->user_data;
 
-    /* initialize AT client */
-    at_client_init(n21->client_name, n21->recv_line_num);
-
     device->client = at_client_get(n21->client_name);
     if (device->client == RT_NULL)
     {
-        LOG_E("n21 device(%s) initialize failed, get AT client(%s) failed.", n21->device_name, n21->client_name);
-        return -RT_ERROR;
+        /* initialize AT client */
+        at_client_init(n21->client_name, n21->recv_line_num);
+
+        device->client = at_client_get(n21->client_name);
+        if (device->client == RT_NULL)
+        {
+            LOG_E("n21 device(%s) initialize failed, get AT client(%s) failed.", n21->device_name, n21->client_name);
+            return -RT_ERROR;
+        }
     }
 
     /* register URC data execution function  */

--- a/class/n58/at_device_n58.c
+++ b/class/n58/at_device_n58.c
@@ -857,14 +857,18 @@ static int n58_init(struct at_device *device)
 {
     struct at_device_n58 *n58 = (struct at_device_n58 *)device->user_data;
 
-    /* initialize AT client */
-    at_client_init(n58->client_name, n58->recv_line_num);
-
     device->client = at_client_get(n58->client_name);
     if (device->client == RT_NULL)
     {
-        LOG_E("n58 device(%s) initialize failed, get AT client(%s) failed.", n58->device_name, n58->client_name);
-        return -RT_ERROR;
+        /* initialize AT client */
+        at_client_init(n58->client_name, n58->recv_line_num);
+
+        device->client = at_client_get(n58->client_name);
+        if (device->client == RT_NULL)
+        {
+            LOG_E("n58 device(%s) initialize failed, get AT client(%s) failed.", n58->device_name, n58->client_name);
+            return -RT_ERROR;
+        }
     }
 
     /* register URC data execution function  */

--- a/class/probe/at_device_probe.c
+++ b/class/probe/at_device_probe.c
@@ -1,0 +1,274 @@
+/*
+ * File      : at_socket_a9g.c
+ * This file is part of RT-Thread RTOS
+ * COPYRIGHT (C) 2006 - 2018, RT-Thread Development Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Change Logs:
+ * Date           Author       Notes
+ * 2020-09-30     DENGs        first version
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <ctype.h>
+
+#include <at_device_probe.h>
+
+#define LOG_TAG                    "at.dev.probe"
+#include <at_log.h>
+ 
+#ifdef AT_DEVICE_USING_PROBE
+
+/* The global list of at device probe kw */
+static rt_slist_t at_device_probe_kw_list = RT_SLIST_OBJECT_INIT(at_device_probe_kw_list);
+
+static int at_device_class_probe_kw_register(rt_slist_t *slist, struct at_device_probe_kw *kw)
+{
+    rt_base_t level;
+    rt_slist_t *node = RT_NULL;
+    struct at_device_probe_kw *kw_iter = RT_NULL;
+
+    level = rt_hw_interrupt_disable();
+
+    if (kw->user_func == RT_NULL)
+    {
+        rt_slist_for_each(node, slist)
+        {
+            kw_iter = rt_slist_entry(node, struct at_device_probe_kw, list);
+            if (kw_iter && \
+                rt_strcmp(kw_iter->kw, kw->kw) == 0 && \
+                rt_strcmp(kw_iter->kw, kw->fmt) == 0)
+            {
+                rt_hw_interrupt_enable(level);
+                return RT_EOK;
+            }
+        }
+    }
+
+    rt_slist_init(&(kw->list));
+    rt_slist_append(slist, &(kw->list));
+
+    rt_hw_interrupt_enable(level);
+
+    return RT_EOK;
+}
+
+int at_device_class_probe_kw_ati_register(struct at_device_probe_kw *kw)
+{
+    RT_ASSERT(kw->kw);
+    RT_ASSERT(kw->fmt);
+    RT_ASSERT(kw->user_func == RT_NULL);
+
+    return at_device_class_probe_kw_register(&at_device_probe_kw_list, kw);
+}
+
+int at_device_class_probe_kw_user_func_register(struct at_device_probe_kw *kw)
+{
+    RT_ASSERT(kw->kw == RT_NULL);
+    RT_ASSERT(kw->fmt == RT_NULL);
+    RT_ASSERT(kw->user_func);
+
+    return at_device_class_probe_kw_register(&at_device_probe_kw_list, kw);
+}
+
+/* AT device class probe thread */
+static void at_device_class_probe_thread_entry(void *parameter)
+{
+    struct at_device *device = (struct at_device *)parameter;
+    struct at_device_probe_param *probe = (struct at_device_probe_param *)device->user_data;
+    at_response_t resp = RT_NULL;
+
+    /* Power init */
+    probe->control(device, AT_DEVICE_PROBE_POWER_INIT, RT_NULL);
+
+    resp = at_create_resp(256, 0, rt_tick_from_millisecond(1000));
+    if (!resp)
+    {
+        LOG_E("No memory for response structure!");
+        return;
+    }
+
+    device->class = RT_NULL;
+
+    while (1)
+    {
+        /* Power on */
+        probe->control(device, AT_DEVICE_CTRL_POWER_ON, RT_NULL);
+        rt_thread_mdelay(5000);
+        
+        /* Wait AT startup finish */
+        if (at_client_obj_wait_connect(device->client, 30 * 1000))
+        {
+            goto __next;
+        }
+
+        /* Disable echo */
+        if (at_obj_exec_cmd(device->client, at_resp_set_info(resp, 256, 0, rt_tick_from_millisecond(1000)), "ATE0") < 0)
+        {
+            goto __next;
+        }
+
+        /* Try get at device model */
+        {
+            rt_slist_t *node = RT_NULL;
+            struct at_device_probe_kw *kw_iter = RT_NULL;
+            char parsed_data[32];
+            int i;
+
+            rt_strncpy(parsed_data, "?", sizeof(parsed_data));
+
+            if (at_obj_exec_cmd(device->client, at_resp_set_info(resp, 256, 0, rt_tick_from_millisecond(1000)), "ATI") < 0)
+            {
+                /* user func, eg: esp8266 */
+                rt_slist_for_each(node, &at_device_probe_kw_list)
+                {
+                    kw_iter = rt_slist_entry(node, struct at_device_probe_kw, list);
+                    if (kw_iter && \
+                        kw_iter->user_func && \
+                        kw_iter->user_func(device->client, resp, parsed_data) == 0)
+                    {
+                        break;
+                    }
+                }
+            }
+            else
+            {
+                /* ati response */
+                rt_slist_for_each(node, &at_device_probe_kw_list)
+                {
+                    kw_iter = rt_slist_entry(node, struct at_device_probe_kw, list);
+                    if (kw_iter && \
+                        !kw_iter->user_func && \
+                        at_resp_parse_line_args_by_kw(resp, kw_iter->kw, kw_iter->fmt, parsed_data) == 1)
+                    {
+                        break;
+                    }
+                }
+            }
+
+            if (parsed_data[0] != '?')
+            {
+                device->class = at_device_class_get_by_name(parsed_data);
+            }
+
+            /* show latest at response */
+            for (i = 0; i < (int) resp->line_counts - 1; i++)
+            {
+                LOG_I("%s", at_resp_get_line(resp, i + 1));
+            }
+            if (device->class == RT_NULL)
+            {
+                LOG_E("client(%s) no class match '%s'", probe->client_name, parsed_data);
+                rt_thread_mdelay(3000);
+                goto __next;
+            }
+        }
+
+    __next:
+        if (device->class != RT_NULL)
+        {
+            break;
+        }
+
+        /* Power off */
+        probe->control(device, AT_DEVICE_CTRL_POWER_OFF, RT_NULL);
+        rt_thread_mdelay(3000);
+    }
+
+    at_delete_resp(resp);
+
+    if (device->class != RT_NULL)
+    {
+        LOG_I("client(%s) match class 0x%04x", probe->client_name, device->class->class_id);
+        
+        /* User register AT device with specific class id */
+        probe->control(device, AT_DEVICE_PROBE_REGISTER, &device->class->class_id);
+    }
+
+    rt_free(device);
+}
+
+static int probe_init(struct at_device *device)
+{
+    struct at_device_probe_param *probe = (struct at_device_probe_param *)device->user_data;
+
+    /* Initialize AT client */
+    at_client_init(probe->client_name, probe->recv_line_num);
+
+    device->client = at_client_get(probe->client_name);
+    if (device->client == RT_NULL)
+    {
+        LOG_E("initialize failed, get AT client(%s) failed.", probe->client_name);
+        return -RT_ERROR;
+    }
+
+    /* Asyn probe AT class */
+    {
+        rt_thread_t tid;
+        
+        tid = rt_thread_create("at_clsp", at_device_class_probe_thread_entry, (void *)device, 2048, RT_THREAD_PRIORITY_MAX / 2, 20);
+        if (tid)
+        {
+            rt_thread_startup(tid);
+        }
+        else
+        {
+            LOG_E("create client(%s) at class probe thread failed.", probe->client_name);
+            rt_free(device);
+            return -RT_ERROR;
+        }
+    }
+
+    return RT_EOK;
+}
+
+static int probe_deinit(struct at_device *device)
+{
+    return RT_EOK;
+}
+
+static int probe_control(struct at_device *device, int cmd, void *arg)
+{
+    return RT_EOK;
+}
+
+const struct at_device_ops probe_device_ops = 
+{
+    probe_init,
+    probe_deinit,
+    probe_control,
+};
+
+static int probe_device_class_register(void)
+{
+    struct at_device_class *class = RT_NULL;
+
+    class = (struct at_device_class *) rt_calloc(1, sizeof(struct at_device_class));
+    if (class == RT_NULL)
+    {
+        LOG_E("no memory for probe device class create.");
+        return -RT_ENOMEM;
+    }
+
+    /* fill probe device class object */
+    class->device_ops = &probe_device_ops;
+
+    return at_device_class_register(class, AT_DEVICE_CLASS_PROBE);
+}
+INIT_DEVICE_EXPORT(probe_device_class_register);
+
+#endif /* AT_DEVICE_USING_PROBE */

--- a/class/probe/at_device_probe.h
+++ b/class/probe/at_device_probe.h
@@ -1,0 +1,66 @@
+/*
+ * File      : at_device_probe.h
+ * This file is part of RT-Thread RTOS
+ * COPYRIGHT (C) 2006 - 2018, RT-Thread Development Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Change Logs:
+ * Date           Author       Notes
+ * 2020-09-30     DENGs        first version
+ */
+ 
+#ifndef __AT_DEVICE_PROBE_H__
+#define __AT_DEVICE_PROBE_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdlib.h>
+
+#include <at_device.h>
+
+/* Options and Commands for AT device probe opreations */
+#define AT_DEVICE_PROBE_POWER_INIT     0x00L
+#define AT_DEVICE_PROBE_POWER_ON       0x01L
+#define AT_DEVICE_PROBE_POWER_OFF      0x02L
+#define AT_DEVICE_PROBE_REGISTER       0x03L
+
+struct at_device_probe_kw
+{
+    const char *kw;
+    const char *fmt;
+    int (*user_func)(at_client_t client, at_response_t resp, char model[32]);
+    rt_slist_t list;
+};
+
+struct at_device_probe_param
+{
+    char *client_name;
+    size_t recv_line_num;
+
+    int (*control)(struct at_device *device, int cmd, void *arg);
+    void *user_data;
+};
+
+int at_device_class_probe_kw_ati_register(struct at_device_probe_kw *kw);
+int at_device_class_probe_kw_user_func_register(struct at_device_probe_kw *kw);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* __AT_DEVICE_PROBE_H__ */

--- a/class/rw007/at_device_rw007.c
+++ b/class/rw007/at_device_rw007.c
@@ -244,14 +244,18 @@ static int rw007_init(struct at_device *device)
 {
     struct at_device_rw007 *rw007 = (struct at_device_rw007 *) device->user_data;
 
-    /* initialize AT client */
-    at_client_init(rw007->client_name, rw007->recv_line_num);
-
     device->client = at_client_get(rw007->client_name);
     if (device->client == RT_NULL)
     {
-        LOG_E("get AT client(%s) failed.", rw007->client_name);
-        return -RT_ERROR;
+        /* initialize AT client */
+        at_client_init(rw007->client_name, rw007->recv_line_num);
+
+        device->client = at_client_get(rw007->client_name);
+        if (device->client == RT_NULL)
+        {
+            LOG_E("get AT client(%s) failed.", rw007->client_name);
+            return -RT_ERROR;
+        }
     }
 
     /* register URC data execution function  */

--- a/class/sim76xx/at_device_sim76xx.c
+++ b/class/sim76xx/at_device_sim76xx.c
@@ -757,14 +757,18 @@ static int sim76xx_init(struct at_device *device)
 {
     struct at_device_sim76xx *sim76xx = (struct at_device_sim76xx *) device->user_data;
 
-    /* initialize AT client */
-    at_client_init(sim76xx->client_name, sim76xx->recv_line_num);
-
     device->client = at_client_get(sim76xx->client_name);
     if (device->client == RT_NULL)
     {
-        LOG_E("get AT client(%s) failed.", sim76xx->client_name);
-        return -RT_ERROR;
+        /* initialize AT client */
+        at_client_init(sim76xx->client_name, sim76xx->recv_line_num);
+
+        device->client = at_client_get(sim76xx->client_name);
+        if (device->client == RT_NULL)
+        {
+            LOG_E("get AT client(%s) failed.", sim76xx->client_name);
+            return -RT_ERROR;
+        }
     }
 
 #ifdef AT_USING_SOCKET

--- a/class/sim800c/at_device_sim800c.c
+++ b/class/sim800c/at_device_sim800c.c
@@ -858,14 +858,18 @@ static int sim800c_init(struct at_device *device)
 {
     struct at_device_sim800c *sim800c = (struct at_device_sim800c *) device->user_data;
 
-    /* initialize AT client */
-    at_client_init(sim800c->client_name, sim800c->recv_line_num);
-
     device->client = at_client_get(sim800c->client_name);
     if (device->client == RT_NULL)
     {
-        LOG_E("get AT client(%s) failed.", sim800c->client_name);
-        return -RT_ERROR;
+        /* initialize AT client */
+        at_client_init(sim800c->client_name, sim800c->recv_line_num);
+
+        device->client = at_client_get(sim800c->client_name);
+        if (device->client == RT_NULL)
+        {
+            LOG_E("get AT client(%s) failed.", sim800c->client_name);
+            return -RT_ERROR;
+        }
     }
 
     /* register URC data execution function  */

--- a/class/w60x/at_device_w60x.c
+++ b/class/w60x/at_device_w60x.c
@@ -792,14 +792,18 @@ static int w60x_init(struct at_device *device)
 {
     struct at_device_w60x *w60x = (struct at_device_w60x *) device->user_data;
 
-    /* initialize AT client */
-    at_client_init(w60x->client_name, w60x->recv_line_num);
-
     device->client = at_client_get(w60x->client_name);
     if (device->client == RT_NULL)
     {
-        LOG_E("get AT client(%s) failed.", w60x->client_name);
-        return -RT_ERROR;
+        /* initialize AT client */
+        at_client_init(w60x->client_name, w60x->recv_line_num);
+
+        device->client = at_client_get(w60x->client_name);
+        if (device->client == RT_NULL)
+        {
+            LOG_E("get AT client(%s) failed.", w60x->client_name);
+            return -RT_ERROR;
+        }
     }
 
     /* register URC data execution function  */

--- a/inc/at_device.h
+++ b/inc/at_device.h
@@ -20,6 +20,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2019-05-08     chenyong     first version
+ * 2020-09-30     DENGs        add at device probe
  */
 
 #ifndef __AT_DEVICE_H__
@@ -44,6 +45,7 @@ extern "C" {
 #define AT_DEVICE_SW_VERSION_NUM       0x20004
 
 /* AT device class ID */
+#define AT_DEVICE_CLASS_PROBE          0x00U
 #define AT_DEVICE_CLASS_ESP8266        0x01U
 #define AT_DEVICE_CLASS_M26_MC20       0x02U
 #define AT_DEVICE_CLASS_EC20           0x03U
@@ -77,6 +79,7 @@ extern "C" {
 #define AT_DEVICE_CTRL_GET_SIGNAL      0x0AL
 #define AT_DEVICE_CTRL_GET_GPS         0x0BL
 #define AT_DEVICE_CTRL_GET_VER         0x0CL
+#define AT_DEVICE_CTRL_REBOOT          0x0DL
 
 /* Name type */
 #define AT_DEVICE_NAMETYPE_DEVICE      0x01
@@ -109,6 +112,10 @@ struct at_device_class
     const struct at_socket_ops *socket_ops;      /* AT device socket operations */
 #endif
     rt_slist_t list;                             /* AT device class list */
+
+#ifdef AT_DEVICE_USING_PROBE
+    const char *compatible[4];
+#endif /* AT_DEVICE_USING_PROBE */
 };
 
 struct at_device
@@ -127,6 +134,9 @@ struct at_device
     void *user_data;                             /* User-specific data */
 };
 
+/* Get AT class object */
+struct at_device_class *at_device_class_get_by_name(const char *name);
+
 /* Get AT device object */
 struct at_device *at_device_get_first_initialized(void);
 struct at_device *at_device_get_by_name(int type, const char *name);
@@ -141,6 +151,10 @@ int at_device_class_register(struct at_device_class *class, uint16_t class_id);
 /* Register AT device object */
 int at_device_register(struct at_device *device, const char *device_name,
                         const char *at_client_name, uint16_t class_id, void *user_data);
+#ifdef AT_DEVICE_USING_PROBE
+/* Probe AT device object */
+int at_device_probe(void *user_data);
+#endif /* AT_DEVICE_USING_PROBE */
 
 #ifdef __cplusplus
 }

--- a/samples/at_sample_probe.c
+++ b/samples/at_sample_probe.c
@@ -1,0 +1,126 @@
+/*
+ * File      : at_sample_probe.c
+ * This file is part of RT-Thread RTOS
+ * COPYRIGHT (C) 2006 - 2018, RT-Thread Development Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Change Logs:
+ * Date           Author       Notes
+ * 2020-09-30     DENGs        first version
+ */
+
+#include <board.h>
+#include "at_device_probe.h"
+#include "at_device_esp8266.h"
+#include "at_device_air720.h"
+#include "at_device_ec200x.h"
+
+#define LOG_TAG                        "at.sample.probe"
+#include <at_log.h>
+
+static int at_device_probe_callback(struct at_device *device, int cmd, void *arg)
+{
+    uint16_t class_id;
+    int power_pin = GET_PIN(C, 8);
+
+    (void)(device);
+
+    switch (cmd)
+    {
+    case AT_DEVICE_PROBE_POWER_INIT:
+        LOG_I("power init");
+        rt_pin_mode(power_pin, PIN_MODE_OUTPUT);
+        break;
+
+    case AT_DEVICE_PROBE_POWER_ON:
+        LOG_I("power on");
+        rt_pin_write(power_pin, PIN_HIGH);
+        break;
+
+    case AT_DEVICE_PROBE_POWER_OFF:
+        LOG_I("power off");
+        rt_pin_write(power_pin, PIN_LOW);
+        break;
+
+    case AT_DEVICE_PROBE_REGISTER:
+        class_id = *(uint16_t *)arg;
+        if (class_id == AT_DEVICE_CLASS_AIR720)
+        {
+            struct at_device_air720 *air720 = rt_calloc(1, sizeof(struct at_device_air720));
+            if (air720 != RT_NULL)
+            {
+                air720->device_name = "e0";
+                air720->client_name = "uart1";
+                air720->power_pin = power_pin;
+                air720->power_status_pin = -1;
+                air720->recv_line_num = 256; /* unused */
+                at_device_register(&air720->device, air720->device_name, air720->client_name, class_id, air720);
+            }
+        }
+        else if (class_id == AT_DEVICE_CLASS_EC200X)
+        {
+            struct at_device_ec200x *ec200x = rt_calloc(1, sizeof(struct at_device_ec200x));
+            if (ec200x != RT_NULL)
+            {
+                ec200x->device_name = "e0";
+                ec200x->client_name = "uart1";
+                ec200x->power_pin = power_pin;
+                ec200x->power_status_pin = -1;
+                ec200x->wakeup_pin = -1;
+                ec200x->recv_line_num = 256; /* unused */
+                at_device_register(&ec200x->device, ec200x->device_name, ec200x->client_name, class_id, ec200x);
+            }
+        }
+        else if (class_id == AT_DEVICE_CLASS_ESP8266)
+        {
+            struct at_device_esp8266 *esp8266 = rt_calloc(1, sizeof(struct at_device_esp8266));
+            if (esp8266 != RT_NULL)
+            {
+                esp8266->device_name = "e0";
+                esp8266->client_name = "uart1";
+                esp8266->wifi_ssid = "ssid";
+                esp8266->wifi_password = "password";
+                esp8266->recv_line_num = 256; /* unused */
+                at_device_register(&esp8266->device, esp8266->device_name, esp8266->client_name, class_id, esp8266);
+            }
+        }
+        else
+        {
+            LOG_E("unknown class 0x%04x", class_id);
+        }
+        break;
+
+    default:
+        break;
+    }
+
+    return 0;
+}
+
+static int sample_device_register(void)
+{
+    static struct at_device_probe_param probe =
+    {
+        "uart1",
+        512,
+        at_device_probe_callback,
+    };
+
+    at_device_probe(&probe);
+    
+    return 0;
+}
+INIT_COMPONENT_EXPORT(sample_device_register);


### PR DESCRIPTION
Useful for hardware changes, pcie module for example.
TODO: user's param 'recv_line_num' have no effect in real at_device_register(), because at_client_init() already done by probe.