### PR TITLE
Add support for unkown provider overseas (SIM800c)

### DIFF
--- a/class/sim800c/at_device_sim800c.c
+++ b/class/sim800c/at_device_sim800c.c
@@ -767,6 +767,11 @@ static void sim800c_init_thread_entry(void *parameter)
             /* "CT" */
             LOG_I("%s device network operator: %s", device->name, parsed_data);
         }
+        else
+        {
+            AT_SEND_CMD(client, resp, 0, 300, "AT+CSTT");
+            LOG_I("%s device network operator: %s", device->name, parsed_data);
+        }
 
         /* the device default response timeout is 150 seconds, but it set to 20 seconds is convenient to use. */
         AT_SEND_CMD(client, resp, 0, 20 * 1000, "AT+CIICR");


### PR DESCRIPTION
Tested with T mobile in the UK.

~~~
[2717] D/at.dev.sim800: 
[2717] D/at.dev.sim800: SIM800 R14.18
[2717] D/at.dev.sim800: 
[2721] D/at.dev.sim800: sim0 device SIM card detection success.
[2734] D/at.dev.sim800: sim0 device GSM is registered(0,1),
[2739] D/at.dev.sim800: sim0 device GPRS is registered(0,1).
[2742] D/at.dev.sim800: sim0 device signal strength: 22,0
[5230] I/at.dev.sim800: sim0 device network operator: T-Mobile
[5624] D/at.dev.sim800: sim0 device IMEI number: 86605003xxxxxxxx
[5628] D/at.dev.sim800: sim0 device IP address: 10.88.xx.xx
[5637] D/at.dev.sim800: sim0 device primary DNS server address: 109.249.xxx.xxx
[5637] D/at.dev.sim800: sim0 device secondary DNS server address: 109.249.xxx.xxx
[5637] I/at.dev.sim800: sim0 device network initialize success!

~~~