### PR TITLE
[fix] delete the usage of "rt_delayed_work".

### DIFF
--- a/class/esp32/at_device_esp32.c
+++ b/class/esp32/at_device_esp32.c
@@ -57,14 +57,13 @@ static void esp32_get_netdev_info(struct rt_work *work, void *work_data)
     rt_uint32_t mac_addr[6] = {0};
     rt_uint32_t num = 0;
     rt_uint32_t dhcp_stat = 0;
-    struct rt_delayed_work *delay_work = (struct rt_delayed_work *)work;
     struct at_device *device = (struct at_device *)work_data;
     struct netdev *netdev = device->netdev;
     struct at_client *client = device->client;
 
-    if (delay_work)
+    if (work != RT_NULL)
     {
-        rt_free(delay_work);
+        rt_free(work);
     }
 
     resp = at_create_resp(512, 0, rt_tick_from_millisecond(300));
@@ -603,15 +602,15 @@ static struct netdev *esp32_netdev_add(const char *netdev_name)
 
 static void esp32_netdev_start_delay_work(struct at_device *device)
 {
-    struct rt_delayed_work *net_work = RT_NULL;
-    net_work = (struct rt_delayed_work *)rt_calloc(1, sizeof(struct rt_delayed_work));
+    struct rt_work *net_work = RT_NULL;
+    net_work = (struct rt_work *)rt_calloc(1, sizeof(struct rt_work));
     if (net_work == RT_NULL)
     {
         return;
     }
 
-    rt_delayed_work_init(net_work, esp32_get_netdev_info, (void *)device);
-    rt_work_submit(&(net_work->work), RT_TICK_PER_SECOND);
+    rt_work_init(net_work, esp32_get_netdev_info, (void *)device);
+    rt_work_submit(net_work, RT_TICK_PER_SECOND);
 }
 
 static void esp32_init_thread_entry(void *parameter)

--- a/class/esp8266/at_device_esp8266.c
+++ b/class/esp8266/at_device_esp8266.c
@@ -58,14 +58,13 @@ static void esp8266_get_netdev_info(struct rt_work *work, void *work_data)
     rt_uint32_t mac_addr[6] = {0};
     rt_uint32_t num = 0;
     rt_uint32_t dhcp_stat = 0;
-    struct rt_delayed_work *delay_work = (struct rt_delayed_work *)work;
     struct at_device *device = (struct at_device *)work_data;
     struct netdev *netdev = device->netdev;
     struct at_client *client = device->client;
 
-    if (delay_work)
+    if (work != RT_NULL)
     {
-        rt_free(delay_work);
+        rt_free(work);
     }
 
     resp = at_create_resp(512, 0, rt_tick_from_millisecond(300));

--- a/class/mw31/at_device_mw31.c
+++ b/class/mw31/at_device_mw31.c
@@ -57,14 +57,13 @@ static void mw31_get_netdev_info(struct rt_work *work, void *work_data)
     rt_uint32_t mac_addr[6] = {0};
     rt_uint32_t num = 0;
     rt_uint8_t dhcp_stat = 0;
-    struct rt_delayed_work *delay_work = (struct rt_delayed_work *)work;
     struct at_device *device = (struct at_device *)work_data;
     struct netdev *netdev = device->netdev;
     struct at_client *client = device->client;
 
-    if (delay_work)
+    if (work != RT_NULL)
     {
-        rt_free(delay_work);
+        rt_free(work);
     }
 
     resp = at_create_resp(512, 0, rt_tick_from_millisecond(300));
@@ -432,15 +431,15 @@ static struct netdev *mw31_netdev_add(const char *netdev_name)
 
 static void mw31_netdev_start_delay_work(struct at_device *device)
 {
-    struct rt_delayed_work *net_work = RT_NULL;
-    net_work = (struct rt_delayed_work *)rt_calloc(1, sizeof(struct rt_delayed_work));
+    struct rt_work *net_work = RT_NULL;
+    net_work = (struct rt_work *)rt_calloc(1, sizeof(struct rt_work));
     if (net_work == RT_NULL)
     {
         return;
     }
 
-    rt_delayed_work_init(net_work, mw31_get_netdev_info, (void *)device);
-    rt_work_submit(&(net_work->work), RT_TICK_PER_SECOND);
+    rt_work_init(net_work, mw31_get_netdev_info, (void *)device);
+    rt_work_submit(net_work, RT_TICK_PER_SECOND);
 }
 
 static void mw31_init_thread_entry(void *parameter)

--- a/class/w60x/at_device_w60x.c
+++ b/class/w60x/at_device_w60x.c
@@ -62,15 +62,14 @@ static void w60x_get_netdev_info(struct rt_work *work, void *work_data)
     rt_uint32_t mac_addr[6] = {0};
     rt_uint32_t num = 0;
     rt_int32_t dhcp_stat = 0;
-    struct rt_delayed_work *delay_work = (struct rt_delayed_work *)work;
     struct at_device *device = (struct at_device *)work_data;
     struct netdev *netdev = device->netdev;
     struct at_client *client = device->client;
     char *pos;
 
-    if (delay_work)
+    if (work != RT_NULL)
     {
-        rt_free(delay_work);
+        rt_free(work);
     }
 
     resp = at_create_resp(512, 1, rt_tick_from_millisecond(3000));
@@ -611,15 +610,15 @@ static struct netdev *w60x_netdev_add(const char *netdev_name)
 
 static void w60x_netdev_start_delay_work(struct at_device *device)
 {
-    struct rt_delayed_work *net_work = RT_NULL;
-    net_work = (struct rt_delayed_work *)rt_calloc(1, sizeof(struct rt_delayed_work));
+    struct rt_work *net_work = RT_NULL;
+    net_work = (struct rt_work *)rt_calloc(1, sizeof(struct rt_work));
     if (net_work == RT_NULL)
     {
         return;
     }
 
-    rt_delayed_work_init(net_work, w60x_get_netdev_info, (void *)device);
-    rt_work_submit(&(net_work->work), RT_TICK_PER_SECOND);
+    rt_work_init(net_work, w60x_get_netdev_info, (void *)device);
+    rt_work_submit(net_work, RT_TICK_PER_SECOND);
 }
 
 static void w60x_init_thread_entry(void *parameter)


### PR DESCRIPTION
* esp32
* esp8266
* mw31
* w60x

The "rt_delayed_work" have been removed in the RT-Thread's repository. https://github.com/RT-Thread-packages/at_device/issues/164