### PR TITLE
[fix] Fibocom L610 bug fix

### DIFF
--- a/class/l610/at_device_l610.c
+++ b/class/l610/at_device_l610.c
@@ -912,7 +912,7 @@ static int l610_net_init(struct at_device *device)
         return -RT_ERROR;
     }
 #else
-    L610_init_thread_entry(device);
+    l610_init_thread_entry(device);
 #endif /* AT_DEVICE_L610_INIT_ASYN */
 
     return RT_EOK;


### PR DESCRIPTION
更正函数名称大小写错误
Correct function name case error