### PR TITLE
Update at_socket_esp32.c

### DIFF
--- a/class/esp32/at_socket_esp32.c
+++ b/class/esp32/at_socket_esp32.c
@@ -327,7 +327,7 @@ static int esp32_domain_resolve(const char *name, char ip[16])
         }
 
         /* parse the third line of response data, get the IP address */
-        if (at_resp_parse_line_args_by_kw(resp, "+CIPDOMAIN:", "+CIPDOMAIN:%s", recv_ip) < 0)
+        if (at_resp_parse_line_args_by_kw(resp, "+CIPDOMAIN:", "+CIPDOMAIN:\"%s\"", recv_ip) < 0)
         {
             rt_thread_mdelay(100);
             /* resolve failed, maybe receive an URC CRLF */


### PR DESCRIPTION
域名解析接收数据的匹配字符有问题，返回的内容格式为：+CIPDOMAIN:”<ip>"，原来的代码会把双引号传入字符串，变成""ip""，然后在后面的at_socket函数调用addr.addr = ipstr_to_u32(ipstr)时，会把IP地址的第1位数字解析成0，从而导致其他问题。