### PR TITLE
fix: struct at_socket_ops * assign error for AT device except ESP8266…

### DIFF
--- a/class/esp8266/at_socket_esp8266.c
+++ b/class/esp8266/at_socket_esp8266.c
@@ -478,7 +478,7 @@ static void esp8266_socket_set_event_cb(at_socket_evt_t event, at_evt_cb_t cb)
     }
 }
 
-static struct at_socket_ops esp8266_socket_ops =
+static const struct at_socket_ops esp8266_socket_ops =
 {
     esp8266_socket_connect,
     esp8266_socket_close,

--- a/inc/at_device.h
+++ b/inc/at_device.h
@@ -94,7 +94,7 @@ struct at_device_class
     const struct at_device_ops *device_ops;      /* AT device operaiotns */
 #ifdef AT_USING_SOCKET
     uint32_t socket_num;                         /* The maximum number of sockets support */
-    struct at_socket_ops *socket_ops;            /* AT device socket operations */
+    const struct at_socket_ops *socket_ops;      /* AT device socket operations */
 #endif
     rt_slist_t list;                             /* AT device class list */
 };


### PR DESCRIPTION
PR #182 修改了 struct at_device_class 的定义，将 socket_ops 成员的 const 限定符去掉了，导致除 ESP8266 以外的其他 AT device 在使用 GCC 编译器编译时出现 `warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]` 编译告警，在 Keil MDK5 中出现 `error: #513: a value of type "const struct at_socket_ops *" cannot be assigned to an entity of type "struct at_socket_ops *"` 错误。

本提交用于修复该问题，已在 BC28、M26、ESP8266 等模块上验证。