### PR TITLE
fix:at_device_register return result

### DIFF
--- a/src/at_device.c
+++ b/src/at_device.c
@@ -291,5 +291,5 @@ __exit:
         device->is_init = RT_TRUE;
     }
 
-    return RT_EOK;
+    return result;
 }


### PR DESCRIPTION
at_device_register根据注册情况返回result，而不是现在只返回个RT_EOK