### PR TITLE
[HUST CSE] [class] fix: Fixed the bug of array out of bounds

### DIFF
--- a/class/mw31/at_socket_mw31.c
+++ b/class/mw31/at_socket_mw31.c
@@ -384,7 +384,7 @@ static void urc_recv_func(struct at_client *client, const char *data, rt_size_t 
     temp[1] = 0;
     for (i = 0; i < 6; i++)
     {
-        if (i > 0 && temp[i-1] != ',')
+        if (i > 0 && temp[i - 1] == ',')
         {
             break;
         }

--- a/class/mw31/at_socket_mw31.c
+++ b/class/mw31/at_socket_mw31.c
@@ -382,7 +382,7 @@ static void urc_recv_func(struct at_client *client, const char *data, rt_size_t 
     sscanf(temp, "%d,", &device_socket);
     temp[0] = 0;
     temp[1] = 0;
-    for (i = 0; i < 6 && temp[i - 1] != ','; i++)
+    for (i = 0; i < 6 && temp[i] != ','; i++)
     {
         at_client_obj_recv(client, &temp[i], 1, 1000);
     }

--- a/class/mw31/at_socket_mw31.c
+++ b/class/mw31/at_socket_mw31.c
@@ -382,8 +382,12 @@ static void urc_recv_func(struct at_client *client, const char *data, rt_size_t 
     sscanf(temp, "%d,", &device_socket);
     temp[0] = 0;
     temp[1] = 0;
-    for (i = 0; i < 6 && temp[i] != ','; i++)
+    for (i = 0; i < 6; i++)
     {
+        if (i > 0 && temp[i-1] != ',')
+        {
+            break;
+        }
         at_client_obj_recv(client, &temp[i], 1, 1000);
     }
     sscanf(temp, "%ld,", &bfsz);


### PR DESCRIPTION
Fixed the bug of array out of bounds. The bug is in class/mw31/at_socket_mw31.c 
Accessing the _temp_ array is out of bounds when the loop starts.