### PR TITLE
[HUST CSE] 修改空指针assert流程错误

### DIFF
--- a/class/esp32/at_device_esp32.c
+++ b/class/esp32/at_device_esp32.c
@@ -729,9 +729,9 @@ static void urc_busy_s_func(struct at_client *client, const char *data, rt_size_
 static void urc_func(struct at_client *client, const char *data, rt_size_t size)
 {
     struct at_device *device = RT_NULL;
-    char *client_name = client->device->parent.name;
 
     RT_ASSERT(client && data && size);
+    char *client_name = client->device->parent.name;
 
     device = at_device_get_by_name(AT_DEVICE_NAMETYPE_CLIENT, client_name);
     if (device == RT_NULL)


### PR DESCRIPTION
### 为什么提交这份PR (why to submit this PR)
断言流程错误，先定义指针再判断断言，在指针client_name时，若client==NULL，则指针client_name会成为空指针，故有错。

此处给出文件路径：
at_device/tree/master/class/esp32)/at_device_esp32.c

查看源码：
 `char *client_name = client->device->parent.name;`
` RT_ASSERT(client && data && size);`

### 你的解决方案是什么 (what is your solution)
先判断断言再定义指针，避免空指针出现可能的bug。
`RT_ASSERT(client && data && size);`
`char *client_name = client->device->parent.name;`


