### PR TITLE
air720 日志缺少了正确的格式化字符串来包含参数，导致程序可能读取无效的参数值引发bus fault

### DIFF
--- a/class/air720/at_device_air720.c
+++ b/class/air720/at_device_air720.c
@@ -224,7 +224,13 @@ static void check_link_status_entry(void *parameter)
     char parsed_data[10] = {0};
     struct netdev *netdev = (struct netdev *)parameter;
 
-    LOG_D("start air720 device(%s) link status check \n");
+    if(netdev == RT_NULL)
+    {
+        LOG_D("netdev pointer is NULL \n");
+        return;
+    }
+
+    LOG_D("start air720 device(%s) link status check \n",netdev->name);
 
     device = at_device_get_by_name(AT_DEVICE_NAMETYPE_NETDEV, netdev->name);
     if (device == RT_NULL)

--- a/class/air720/at_device_air720.c
+++ b/class/air720/at_device_air720.c
@@ -226,7 +226,7 @@ static void check_link_status_entry(void *parameter)
 
     if(netdev == RT_NULL)
     {
-        LOG_E("netdev pointer is NULL \n");
+        LOG_E("netdev pointer is NULL");
         return;
     }
 

--- a/class/air720/at_device_air720.c
+++ b/class/air720/at_device_air720.c
@@ -230,7 +230,7 @@ static void check_link_status_entry(void *parameter)
         return;
     }
 
-    LOG_D("start air720 device(%s) link status check \n",netdev->name);
+    LOG_D("start air720 device(%s) link status check", netdev->name);
 
     device = at_device_get_by_name(AT_DEVICE_NAMETYPE_NETDEV, netdev->name);
     if (device == RT_NULL)

--- a/class/air720/at_device_air720.c
+++ b/class/air720/at_device_air720.c
@@ -226,7 +226,7 @@ static void check_link_status_entry(void *parameter)
 
     if(netdev == RT_NULL)
     {
-        LOG_D("netdev pointer is NULL \n");
+        LOG_E("netdev pointer is NULL \n");
         return;
     }
 


### PR DESCRIPTION
air720 日志缺少了正确的格式化字符串来包含参数，导致程序可能读取无效的参数值引发bus fault