### PR TITLE
[fix]添加ESP8266 ESP32 AT指令版本号获取API

### DIFF
--- a/class/esp32/at_device_esp32.c
+++ b/class/esp32/at_device_esp32.c
@@ -22,6 +22,7 @@
 #define ESP32_WAIT_CONNECT_TIME      5000
 #define ESP32_THREAD_STACK_SIZE      2048
 #define ESP32_THREAD_PRIORITY        (RT_THREAD_PRIORITY_MAX / 2)
+unsigned int ESP32_GMR_AT_VERSION;
 
 /* =============================  esp32 network interface operations ============================= */
 
@@ -408,7 +409,8 @@ static int esp32_netdev_ping(struct netdev *netdev, const char *host,
     }
 
     /* parse the third line of response data, get the IP address */
-    if (at_resp_parse_line_args_by_kw(resp, "+CIPDOMAIN:", "+CIPDOMAIN:\"%[^\"]\"", ip_addr) < 0)
+    if (at_resp_parse_line_args_by_kw(resp, "+CIPDOMAIN:", (esp32_get_at_version() <= ESP32_DEFAULT_AT_VERSION_NUM) ? \
+                                      "+CIPDOMAIN:%s" : "+CIPDOMAIN:\"%[^\"]\"", ip_addr) < 0)
     {
         result = -RT_ERROR;
         goto __exit;
@@ -421,7 +423,8 @@ static int esp32_netdev_ping(struct netdev *netdev, const char *host,
         goto __exit;
     }
 
-    if (at_resp_parse_line_args_by_kw(resp, "+", "+PING:%d", &req_time) < 0)
+    if (at_resp_parse_line_args_by_kw(resp, "+", (esp32_get_at_version() <= ESP32_DEFAULT_AT_VERSION_NUM) ? 
+                                      "+%d" : "+PING:%d", &req_time) < 0)
     {
         result = -RT_ERROR;
         goto __exit;
@@ -638,6 +641,7 @@ static void esp32_init_thread_entry(void *parameter)
         AT_SEND_CMD(client, resp, "AT+CWMODE=1");
         /* get module version */
         AT_SEND_CMD(client, resp, "AT+GMR");
+        ESP32_GMR_AT_VERSION = esp32_at_version_to_hex(at_resp_get_line(resp, 1));
         /* show module version */
         for (i = 0; i < resp->line_counts - 1; i++)
         {
@@ -930,4 +934,57 @@ static int esp32_device_class_register(void)
 }
 INIT_DEVICE_EXPORT(esp32_device_class_register);
 
+/**
+ * Convert the ESP32 AT version string to hexadecimal
+ *
+ * @param string containing the AT version
+ *
+ * @return hex_number: Hexadecimal AT version number, example: 1.4.1.1 -> 0x1040101
+ */
+unsigned int esp32_at_version_to_hex(const char *str)
+{
+    const char *version_prefix = "AT version:";
+    char *version_start;
+    unsigned int numbers[4];
+    unsigned int hex_number;
+
+    if (str == NULL || *str == '\0')
+    {
+        LOG_E("Invalid AT version format\n");
+        return 0;
+    }
+
+    /* Get AT version string */
+    version_start = strstr(str, version_prefix);
+    if (version_start)
+    {
+        if (sscanf(version_start, "AT version:%d.%d.%d.%d", &numbers[0], &numbers[1], &numbers[2], &numbers[3]) == 4)
+        {
+
+            hex_number = (numbers[0] << 24) | (numbers[1] << 16) | (numbers[2] << 8) | numbers[3];
+        }
+        else
+        {
+            LOG_W("The AT instruction format is not standard\n");
+            return 0;
+        }
+    }
+    else
+    {
+        LOG_W("The AT+GMR instruction is not supported\n");
+        return 0;
+    }
+
+    return hex_number;
+}
+
+/**
+ * This function is used to obtain the ESP32 AT version number.
+ *
+ * @return hex_number: Hexadecimal AT version number, example: 1.4.1.1 -> 0x1040101
+ */
+unsigned int esp32_get_at_version(void)
+{
+    return ESP32_GMR_AT_VERSION;
+}
 #endif /* AT_DEVICE_USING_ESP32 */

--- a/class/esp32/at_device_esp32.h
+++ b/class/esp32/at_device_esp32.h
@@ -18,6 +18,8 @@ extern "C" {
 #include <stdlib.h>
 
 #include <at_device.h>
+#define ESP32_DEFAULT_AT_VERSION         "1.4.0.0"
+#define ESP32_DEFAULT_AT_VERSION_NUM     0x1040000
 
 /* The maximum number of sockets supported by the esp32 device */
 #define AT_DEVICE_ESP32_SOCKETS_NUM  5
@@ -43,6 +45,11 @@ int esp32_socket_init(struct at_device *device);
 /* esp32 device class socket register */
 int esp32_socket_class_register(struct at_device_class *class);
 
+/* convert the esp32 AT version string to hexadecimal */
+unsigned int esp32_at_version_to_hex(const char *str);
+
+/* obtain the esp32 AT version number */
+unsigned int esp32_get_at_version(void);
 #endif /* AT_USING_SOCKET */
 
 #ifdef __cplusplus

--- a/class/esp32/at_socket_esp32.c
+++ b/class/esp32/at_socket_esp32.c
@@ -327,7 +327,8 @@ static int esp32_domain_resolve(const char *name, char ip[16])
         }
 
         /* parse the third line of response data, get the IP address */
-        if (at_resp_parse_line_args_by_kw(resp, "+CIPDOMAIN:", "+CIPDOMAIN:\"%[^\"]\"", recv_ip) < 0)
+
+        if (at_resp_parse_line_args_by_kw(resp, "+CIPDOMAIN:", (esp32_get_at_version() <= ESP32_DEFAULT_AT_VERSION_NUM) ? "+CIPDOMAIN:%s" : "+CIPDOMAIN:\"%[^\"]\"", recv_ip) < 0)
         {
             rt_thread_mdelay(100);
             /* resolve failed, maybe receive an URC CRLF */

--- a/class/esp8266/at_device_esp8266.h
+++ b/class/esp8266/at_device_esp8266.h
@@ -18,6 +18,8 @@ extern "C" {
 #include <stdlib.h>
 
 #include <at_device.h>
+#define ESP8266_DEFAULT_AT_VERSION         "1.4.0.0"
+#define ESP8266_DEFAULT_AT_VERSION_NUM     0x1040000
 
 /* The maximum number of sockets supported by the esp8266 device */
 #define AT_DEVICE_ESP8266_SOCKETS_NUM  5
@@ -43,6 +45,11 @@ int esp8266_socket_init(struct at_device *device);
 /* esp8266 device class socket register */
 int esp8266_socket_class_register(struct at_device_class *class);
 
+/* convert the esp8266 AT version string to hexadecimal */
+unsigned int esp8266_at_version_to_hex(const char *str);
+
+/* obtain the esp8266 AT version number */
+unsigned int esp8266_get_at_version(void);
 #endif /* AT_USING_SOCKET */
 
 #ifdef __cplusplus

--- a/class/esp8266/at_socket_esp8266.c
+++ b/class/esp8266/at_socket_esp8266.c
@@ -422,7 +422,9 @@ static int esp8266_domain_resolve(const char *name, char ip[16])
         }
 
         /* parse the third line of response data, get the IP address */
-        if (at_resp_parse_line_args_by_kw(resp, "+CIPDOMAIN:", "+CIPDOMAIN:\"%[^\"]\"", recv_ip) < 0)
+
+        if (at_resp_parse_line_args_by_kw(resp, "+CIPDOMAIN:", (esp8266_get_at_version() <= ESP8266_DEFAULT_AT_VERSION_NUM) ? \
+                                      "+CIPDOMAIN:%s" : "+CIPDOMAIN:\"%[^\"]\"", recv_ip) < 0)
         {
             rt_thread_mdelay(100);
             /* resolve failed, maybe receive an URC CRLF */


### PR DESCRIPTION
【问题】使用AT组件无法 执行 ping www.baidu.com 获取正确IP
【原因】不同AT固件的AT指令的版本可能不同 导致AT指令格式不同
【解决思路】为设备定义AT指令版本的宏 通过该宏去判断使用哪个版本AT指令的格式 后续因AT指令版本引入的问题均使用该宏去区分
【解决办法】使用AT+GMR指令获取设备的AT指令版本号 这块具体设备的内容会不同 所以针对具体的AT需具体实现 
修复最新版本的at组件esp8266 ping不通的问题 支持安信可固件版本v1.7.1以上
固件地址：https://docs.ai-thinker.com/%E5%9B%BA%E4%BB%B6%E6%B1%87%E6%80%BB