### PR TITLE
🐞 fix(socket): 修复esp32多socket连接时的异常

### DIFF
--- a/class/esp32/at_device_esp32.h
+++ b/class/esp32/at_device_esp32.h
@@ -34,9 +34,17 @@ struct at_device_esp32
     size_t recv_line_num;
     struct at_device device;
 
+    uint16_t urc_socket;
     void *user_data;
 };
-
+typedef struct at_AP_INFO
+{
+    uint8_t ecn;       /* 加密方式 */
+    char ssid[32];     /* 无线网络名称，最多31字节 + 终止符 */
+    int8_t rssi;       /* 信号强度 */
+    uint8_t mac[6];    /* MAC地址 */
+    uint8_t channel;   /* 频道 */
+} at_ap_info_t;
 #ifdef AT_USING_SOCKET
 
 /* esp32 device socket initialize */
@@ -52,6 +60,8 @@ unsigned int esp32_at_version_to_hex(const char *str);
 unsigned int esp32_get_at_version(void);
 #endif /* AT_USING_SOCKET */
 
+/* scan the AP information */
+int esp32_scan_ap(struct at_device *device, at_ap_info_t *ap_info, uint8_t num);
 #ifdef __cplusplus
 }
 #endif

--- a/inc/at_device.h
+++ b/inc/at_device.h
@@ -71,7 +71,7 @@ extern "C" {
 #define AT_DEVICE_CTRL_GET_SIGNAL      0x0AL
 #define AT_DEVICE_CTRL_GET_GPS         0x0BL
 #define AT_DEVICE_CTRL_GET_VER         0x0CL
-
+#define AT_DEVICE_CTRL_SET_HOST_NAME   0x0DL
 /* Name type */
 #define AT_DEVICE_NAMETYPE_DEVICE      0x01
 #define AT_DEVICE_NAMETYPE_NETDEV      0x02

--- a/samples/at_sample_esp32.c
+++ b/samples/at_sample_esp32.c
@@ -33,6 +33,6 @@ static int esp32_device_register(void)
                               esp32->device_name,
                               esp32->client_name,
                               AT_DEVICE_CLASS_ESP32,
-                              (void *) esp32);
+                              (void *) NULL);
 }
 INIT_APP_EXPORT(esp32_device_register);


### PR DESCRIPTION
1. 调整device->user_data; 到struct at_device_esp32 节省user_data使用
2. 增加设备hostname操作
3. 增加ap扫描操作
4. 补全server模式下urc操作
5. 调整esp32_socket_event_send中暂存的socket为urc_socket
6. 增加server模式下关闭listen操作

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wi‑Fi AP scanning to list nearby networks (SSID, security, RSSI, channel, MAC)
  * Device hostname configuration via a new control command
  * Socket server mode to listen for and accept incoming connections

* **Refactor**
  * Safer device/socket context handling and improved URC/event processing for more reliable networking

* **Chores**
  * Updated comments and terminology to reflect ESP32 behavior

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->